### PR TITLE
chore: restore baseline quality gates

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,6 +22,19 @@ jobs:
     with:
       release: ${{ github.event.inputs.release }}
 
+  quality:
+    name: Quality Gates
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Setup
+        uses: ./.github/actions/setup
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+      - name: Check
+        run: pnpm check
+
   cms-plugin-build:
     name: "cms-plugin: Build"
     runs-on: ubuntu-latest

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -112,6 +112,7 @@ jobs:
     name: Create release
     runs-on: ubuntu-latest
     needs:
+      - quality
       - cms-plugin-build
       - common-build
       - releaser-build

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,9 @@
+**/.next/
+**/build/
+**/dist/
+**/node_modules/
+**/temp/
+LICENSE.md
+examples/cms-example/src/app/(payload)/admin/importMap.js
+examples/cms-example/src/payload-types.ts
+pnpm-lock.yaml

--- a/examples/cms-example/.prettierignore
+++ b/examples/cms-example/.prettierignore
@@ -1,0 +1,2 @@
+src/app/(payload)/admin/importMap.js
+src/payload-types.ts

--- a/libs/cms-plugin/package.json
+++ b/libs/cms-plugin/package.json
@@ -13,7 +13,7 @@
     "build:types": "tsc --outDir dist --rootDir ./src",
     "clean": "rimraf {dist,*.tsbuildinfo}",
     "copyfiles": "copyfiles -u 1 \"src/**/*.{html,css,scss,ttf,woff,woff2,eot,svg,jpg,png,json}\" dist/",
-    "lint": "eslint",
+    "lint": "eslint src",
     "lint:fix": "eslint ./src --fix",
     "test": "pnpm test:int && pnpm test:e2e",
     "test:e2e": "playwright test",

--- a/libs/cms-plugin/src/common/cn.ts
+++ b/libs/cms-plugin/src/common/cn.ts
@@ -5,7 +5,7 @@ export function cn(...args: ClassNameConfig[]): string {
     .join(" ");
 }
 
-function isApplicable(arg: ClassNameConfig): arg is string | object {
+function isApplicable(arg: ClassNameConfig): arg is object | string {
   return !!arg && arg !== true;
 }
 
@@ -15,4 +15,4 @@ function objectToClasses(obj: object): string[] {
     .map(([className]) => className);
 }
 
-type ClassNameConfig = boolean | undefined | null | string | object;
+type ClassNameConfig = boolean | null | object | string | undefined;

--- a/libs/cms-plugin/tests/common/cn.test.ts
+++ b/libs/cms-plugin/tests/common/cn.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from "vitest";
+
+import { cn } from "../../src/common/cn.js";
+
+describe("cn", () => {
+  it("joins string class names in order", () => {
+    expect(cn("button", "button--primary")).toBe("button button--primary");
+  });
+
+  it("omits falsey and boolean-only values", () => {
+    expect(cn("button", false, null, undefined, true, "")).toBe("button");
+  });
+
+  it("includes object keys with truthy values", () => {
+    expect(
+      cn("button", {
+        "button--disabled": false,
+        "button--loading": true,
+        "button--primary": 1,
+      }),
+    ).toBe("button button--loading button--primary");
+  });
+});

--- a/libs/cms-plugin/tests/common/cn.test.ts
+++ b/libs/cms-plugin/tests/common/cn.test.ts
@@ -7,7 +7,7 @@ describe("cn", () => {
     expect(cn("button", "button--primary")).toBe("button button--primary");
   });
 
-  it("omits falsey and boolean-only values", () => {
+  it("omits falsy and boolean-only values", () => {
     expect(cn("button", false, null, undefined, true, "")).toBe("button");
   });
 

--- a/package.json
+++ b/package.json
@@ -1,4 +1,11 @@
 {
+  "scripts": {
+    "build": "pnpm -r --if-present run build",
+    "check": "pnpm format:check && pnpm lint && pnpm test",
+    "format:check": "pnpm -r --if-present run check-format",
+    "lint": "pnpm -r --if-present run lint",
+    "test": "pnpm -r --if-present run test:int"
+  },
   "packageManager": "pnpm@10.3.0+sha512.ee592eda8815a8a293c206bb0917c4bb0ff274c50def7cbc17be05ec641fc2d1b02490ce660061356bd0d126a4d7eb2ec8830e6959fb8a447571c631d5a2442d",
   "devDependencies": {
     "@fxmk/releaser": "^0.0.2-main.60",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "scripts": {
     "build": "pnpm -r --if-present run build",
     "check": "pnpm format:check && pnpm lint && pnpm test",
-    "format:check": "pnpm -r --if-present run check-format",
+    "format:check": "prettier --check .",
     "lint": "pnpm -r --if-present run lint",
     "test": "pnpm -r --if-present run test:int"
   },


### PR DESCRIPTION
## Summary
- add root maintenance scripts for build, lint, format, test, and check
- scope cms-plugin linting to source files and fix the existing cn lint errors
- add Vitest coverage for cn so integration tests have a real test target
- ignore Payload-generated example files in Prettier checks
- add a CI quality job that runs pnpm check

## Notes
This intentionally does not update Payload, Next, OpenAI, or other dependencies. The current audit findings remain follow-up work for a dedicated dependency/security PR.

## Validation
- pnpm install --frozen-lockfile
- pnpm lint
- pnpm test
- pnpm format:check
- pnpm check
- pnpm -r --if-present run build
