### PR TITLE
chore: update openai and zod

### DIFF
--- a/libs/cms-plugin/package.json
+++ b/libs/cms-plugin/package.json
@@ -64,8 +64,8 @@
   "dependencies": {
     "@payloadcms/translations": "3.84.1",
     "deepl-node": "^1.27.0",
-    "openai": "^5.12.2",
-    "zod": "^3.25.76"
+    "openai": "^6.38.0",
+    "zod": "^4.4.3"
   },
   "engines": {
     "node": "^20.19.0 || >=22.12.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -116,11 +116,11 @@ importers:
         specifier: ^1.27.0
         version: 1.27.0
       openai:
-        specifier: ^5.12.2
-        version: 5.12.2(ws@8.18.3)(zod@3.25.76)
+        specifier: ^6.38.0
+        version: 6.38.0(ws@8.18.3)(zod@4.4.3)
       zod:
-        specifier: ^3.25.76
-        version: 3.25.76
+        specifier: ^4.4.3
+        version: 4.4.3
     devDependencies:
       '@eslint/eslintrc':
         specifier: ^3.3.5
@@ -4963,12 +4963,12 @@ packages:
     resolution: {integrity: sha512-YgBpdJHPyQ2UE5x+hlSXcnejzAvD0b22U2OuAP+8OnlJT+PjWPxtgmGqKKc+RgTM63U9gN0YzrYc71R2WT/hTA==}
     engines: {node: '>=18'}
 
-  openai@5.12.2:
-    resolution: {integrity: sha512-xqzHHQch5Tws5PcKR2xsZGX9xtch+JQFz5zb14dGqlshmmDAFBFEWmeIpf7wVqWV+w7Emj7jRgkNJakyKE0tYQ==}
+  openai@6.38.0:
+    resolution: {integrity: sha512-AoMplt2UalrpgUDMh3L09QWjNRlgJPipclQvA6sYAaeF6nHNBMgmikAZGmcYLn8on4d9sQY9Q8bOLfrBS7Lc8g==}
     hasBin: true
     peerDependencies:
       ws: ^8.18.0
-      zod: ^3.23.8
+      zod: ^3.25 || ^4.0
     peerDependenciesMeta:
       ws:
         optional: true
@@ -6253,8 +6253,8 @@ packages:
     peerDependencies:
       zod: ^3.25.0 || ^4.0.0
 
-  zod@3.25.76:
-    resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
+  zod@4.4.3:
+    resolution: {integrity: sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==}
 
   zwitch@2.0.4:
     resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}
@@ -7597,11 +7597,11 @@ snapshots:
       deepl-node: 1.27.0
       jsdom: 26.1.0
       next: 16.2.6(@babel/core@7.29.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.77.4)
-      openai: 5.12.2(ws@8.18.3)(zod@3.25.76)
+      openai: 6.38.0(ws@8.18.3)(zod@4.4.3)
       payload: 3.84.1(graphql@16.11.0)(typescript@5.7.3)
       react: 19.2.6
       react-dom: 19.2.6(react@19.2.6)
-      zod: 3.25.76
+      zod: 4.4.3
     transitivePeerDependencies:
       - debug
       - supports-color
@@ -10630,8 +10630,8 @@ snapshots:
       '@babel/parser': 7.28.0
       eslint: 9.33.0(jiti@2.5.1)
       hermes-parser: 0.25.1
-      zod: 3.25.76
-      zod-validation-error: 4.0.2(zod@3.25.76)
+      zod: 4.4.3
+      zod-validation-error: 4.0.2(zod@4.4.3)
     transitivePeerDependencies:
       - supports-color
 
@@ -12182,10 +12182,10 @@ snapshots:
       is-inside-container: 1.0.0
       wsl-utils: 0.1.0
 
-  openai@5.12.2(ws@8.18.3)(zod@3.25.76):
+  openai@6.38.0(ws@8.18.3)(zod@4.4.3):
     optionalDependencies:
       ws: 8.18.3
-      zod: 3.25.76
+      zod: 4.4.3
 
   optionator@0.9.4:
     dependencies:
@@ -13629,10 +13629,10 @@ snapshots:
 
   yoctocolors@2.1.2: {}
 
-  zod-validation-error@4.0.2(zod@3.25.76):
+  zod-validation-error@4.0.2(zod@4.4.3):
     dependencies:
-      zod: 3.25.76
+      zod: 4.4.3
 
-  zod@3.25.76: {}
+  zod@4.4.3: {}
 
   zwitch@2.0.4: {}


### PR DESCRIPTION
## Summary
- update openai to ^6.38.0
- update zod to ^4.4.3 for the OpenAI v6 peer range
- refresh pnpm-lock.yaml

## Verification
- pnpm install --frozen-lockfile
- pnpm --filter @fxmk/cms-plugin build
- pnpm --filter @fxmk/cms-plugin lint
- pnpm --filter @fxmk/cms-plugin test:int
