### PR TITLE
ci(actions): upgrade GitHub Actions

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -4,9 +4,9 @@ runs:
   using: "composite"
   steps:
     - name: Install PNPM
-      uses: pnpm/action-setup@v4
+      uses: pnpm/action-setup@v6.0.8
     - name: Set up Node.js with PNPM cache
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@v6.4.0
       with:
         node-version: ${{ env.NODE_VERSION }}
         cache: "pnpm"

--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -4,9 +4,9 @@ runs:
   using: "composite"
   steps:
     - name: Install PNPM
-      uses: pnpm/action-setup@v6.0.8
+      uses: pnpm/action-setup@v6
     - name: Set up Node.js with PNPM cache
-      uses: actions/setup-node@v6.4.0
+      uses: actions/setup-node@v6
       with:
         node-version: ${{ env.NODE_VERSION }}
         cache: "pnpm"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,7 +27,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@v6
       - name: Setup
         uses: ./.github/actions/setup
       - name: Install dependencies
@@ -40,7 +40,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@v6
       - name: Setup
         uses: ./.github/actions/setup
       - name: Build
@@ -48,7 +48,7 @@ jobs:
         with:
           package: "cms-plugin"
       - name: Upload cms-plugin 'dist' directory
-        uses: actions/upload-artifact@v7.0.1
+        uses: actions/upload-artifact@v7
         with:
           name: cms-plugin-dist
           path: libs/cms-plugin/dist
@@ -58,7 +58,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@v6
       - name: Setup
         uses: ./.github/actions/setup
       - name: Build
@@ -66,7 +66,7 @@ jobs:
         with:
           package: "common"
       - name: Upload common 'dist' directory
-        uses: actions/upload-artifact@v7.0.1
+        uses: actions/upload-artifact@v7
         with:
           name: common-dist
           path: libs/common/dist
@@ -77,11 +77,11 @@ jobs:
     needs: [cms-plugin-build]
     steps:
       - name: Checkout
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@v6
       - name: Setup
         uses: ./.github/actions/setup
       - name: Download cms-plugin 'dist' directory
-        uses: actions/download-artifact@v8.0.1
+        uses: actions/download-artifact@v8
         with:
           name: cms-plugin-dist
           path: libs/cms-plugin/dist
@@ -104,7 +104,7 @@ jobs:
       contents: write
     steps:
       - name: Checkout with full history
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
       - name: Setup
@@ -126,11 +126,11 @@ jobs:
       id-token: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@v6
       - name: Setup
         uses: ./.github/actions/setup
       - name: Download cms-plugin 'dist' directory
-        uses: actions/download-artifact@v8.0.1
+        uses: actions/download-artifact@v8
         with:
           name: cms-plugin-dist
           path: libs/cms-plugin/dist
@@ -150,11 +150,11 @@ jobs:
       id-token: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@v6
       - name: Setup
         uses: ./.github/actions/setup
       - name: Download common 'dist' directory
-        uses: actions/download-artifact@v8.0.1
+        uses: actions/download-artifact@v8
         with:
           name: common-dist
           path: libs/common/dist

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,7 +27,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6.0.2
       - name: Setup
         uses: ./.github/actions/setup
       - name: Install dependencies
@@ -40,7 +40,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6.0.2
       - name: Setup
         uses: ./.github/actions/setup
       - name: Build
@@ -48,7 +48,7 @@ jobs:
         with:
           package: "cms-plugin"
       - name: Upload cms-plugin 'dist' directory
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7.0.1
         with:
           name: cms-plugin-dist
           path: libs/cms-plugin/dist
@@ -58,7 +58,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6.0.2
       - name: Setup
         uses: ./.github/actions/setup
       - name: Build
@@ -66,7 +66,7 @@ jobs:
         with:
           package: "common"
       - name: Upload common 'dist' directory
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7.0.1
         with:
           name: common-dist
           path: libs/common/dist
@@ -77,11 +77,11 @@ jobs:
     needs: [cms-plugin-build]
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6.0.2
       - name: Setup
         uses: ./.github/actions/setup
       - name: Download cms-plugin 'dist' directory
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8.0.1
         with:
           name: cms-plugin-dist
           path: libs/cms-plugin/dist
@@ -104,7 +104,7 @@ jobs:
       contents: write
     steps:
       - name: Checkout with full history
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6.0.2
         with:
           fetch-depth: 0
       - name: Setup
@@ -126,11 +126,11 @@ jobs:
       id-token: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6.0.2
       - name: Setup
         uses: ./.github/actions/setup
       - name: Download cms-plugin 'dist' directory
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8.0.1
         with:
           name: cms-plugin-dist
           path: libs/cms-plugin/dist
@@ -150,11 +150,11 @@ jobs:
       id-token: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6.0.2
       - name: Setup
         uses: ./.github/actions/setup
       - name: Download common 'dist' directory
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8.0.1
         with:
           name: common-dist
           path: libs/common/dist

--- a/.github/workflows/export.build.yml
+++ b/.github/workflows/export.build.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@v6
       - name: Setup
         uses: felixmokross/webplatform/.github/actions/setup@main
       - name: Install CMS dependencies
@@ -28,7 +28,7 @@ jobs:
       - name: Pull CMS types
         run: pnpm --filter payload-types pull-payload-types
       - name: Upload CMS types
-        uses: actions/upload-artifact@v7.0.1
+        uses: actions/upload-artifact@v7
         with:
           name: payload-types
           path: libs/payload-types/src/payload-types.ts
@@ -38,7 +38,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@v6
       - name: Setup
         uses: felixmokross/webplatform/.github/actions/setup@main
       - name: Install dependencies
@@ -51,7 +51,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@v6
       - name: Setup
         uses: felixmokross/webplatform/.github/actions/setup@main
       - name: Install dependencies
@@ -65,11 +65,11 @@ jobs:
     needs: populate-cms-types
     steps:
       - name: Checkout
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@v6
       - name: Setup
         uses: felixmokross/webplatform/.github/actions/setup@main
       - name: Download CMS types
-        uses: actions/download-artifact@v8.0.1
+        uses: actions/download-artifact@v8
         with:
           name: payload-types
           path: libs/payload-types/src
@@ -83,7 +83,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@v6
       - name: Setup
         uses: felixmokross/webplatform/.github/actions/setup@main
       - name: Install dependencies
@@ -99,7 +99,7 @@ jobs:
       image: ${{ steps.image-name.outputs.image }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@v6
       - name: Set up flyctl
         uses: superfly/flyctl-actions/setup-flyctl@master
         with:
@@ -111,7 +111,7 @@ jobs:
           pnpm version ${{ needs.version.outputs.version }} --git-tag-version false
         working-directory: apps/frontend
       - name: Download CMS types
-        uses: actions/download-artifact@v8.0.1
+        uses: actions/download-artifact@v8
         with:
           name: payload-types
           path: libs/payload-types/src
@@ -141,7 +141,7 @@ jobs:
     needs: [populate-cms-types]
     steps:
       - name: Checkout with full history
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
       - name: Setup
@@ -149,7 +149,7 @@ jobs:
       - name: Install dependencies for frontend
         run: pnpm --filter frontend install
       - name: Download CMS types
-        uses: actions/download-artifact@v8.0.1
+        uses: actions/download-artifact@v8
         with:
           name: payload-types
           path: libs/payload-types/src
@@ -172,7 +172,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@v6
       - name: Setup
         uses: felixmokross/webplatform/.github/actions/setup@main
       - name: Install dependencies
@@ -185,7 +185,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@v6
       - name: Setup
         uses: felixmokross/webplatform/.github/actions/setup@main
       - name: Install dependencies
@@ -201,7 +201,7 @@ jobs:
       image: ${{ steps.image-name.outputs.image }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@v6
       - name: Set up flyctl
         uses: superfly/flyctl-actions/setup-flyctl@master
         with:
@@ -241,7 +241,7 @@ jobs:
       CMS_API_KEY: e2e-tests-apikey
     steps:
       - name: Checkout
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@v6
       - name: Setup
         uses: felixmokross/webplatform/.github/actions/setup@main
       - name: Install dependencies for e2e
@@ -278,7 +278,7 @@ jobs:
           echo "playwright_version=${PLAYWRIGHT_VERSION}" >> $GITHUB_OUTPUT
         working-directory: tests/e2e
       - name: Cache Playwright browsers
-        uses: actions/cache@v5.0.5
+        uses: actions/cache@v5
         id: playwright-cache
         with:
           path: ~/.cache/ms-playwright
@@ -290,7 +290,7 @@ jobs:
         if: steps.playwright-cache.outputs.cache-hit != 'true'
         working-directory: tests/e2e
       - name: Download CMS types
-        uses: actions/download-artifact@v8.0.1
+        uses: actions/download-artifact@v8
         with:
           name: payload-types
           path: libs/payload-types/src
@@ -303,7 +303,7 @@ jobs:
           CMS_API_KEY: ${{ env.CMS_API_KEY }}
           EXPECTED_VERSION: ${{ needs.version.outputs.version }}
       - name: Upload Playwright report
-        uses: actions/upload-artifact@v7.0.1
+        uses: actions/upload-artifact@v7
         if: always()
         with:
           name: playwright-report
@@ -355,7 +355,7 @@ jobs:
       contents: write
     steps:
       - name: Checkout with full history
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
       - name: Setup

--- a/.github/workflows/export.build.yml
+++ b/.github/workflows/export.build.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6.0.2
       - name: Setup
         uses: felixmokross/webplatform/.github/actions/setup@main
       - name: Install CMS dependencies
@@ -28,7 +28,7 @@ jobs:
       - name: Pull CMS types
         run: pnpm --filter payload-types pull-payload-types
       - name: Upload CMS types
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7.0.1
         with:
           name: payload-types
           path: libs/payload-types/src/payload-types.ts
@@ -38,7 +38,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6.0.2
       - name: Setup
         uses: felixmokross/webplatform/.github/actions/setup@main
       - name: Install dependencies
@@ -51,7 +51,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6.0.2
       - name: Setup
         uses: felixmokross/webplatform/.github/actions/setup@main
       - name: Install dependencies
@@ -65,11 +65,11 @@ jobs:
     needs: populate-cms-types
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6.0.2
       - name: Setup
         uses: felixmokross/webplatform/.github/actions/setup@main
       - name: Download CMS types
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8.0.1
         with:
           name: payload-types
           path: libs/payload-types/src
@@ -83,7 +83,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6.0.2
       - name: Setup
         uses: felixmokross/webplatform/.github/actions/setup@main
       - name: Install dependencies
@@ -99,7 +99,7 @@ jobs:
       image: ${{ steps.image-name.outputs.image }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6.0.2
       - name: Set up flyctl
         uses: superfly/flyctl-actions/setup-flyctl@master
         with:
@@ -111,7 +111,7 @@ jobs:
           pnpm version ${{ needs.version.outputs.version }} --git-tag-version false
         working-directory: apps/frontend
       - name: Download CMS types
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8.0.1
         with:
           name: payload-types
           path: libs/payload-types/src
@@ -141,7 +141,7 @@ jobs:
     needs: [populate-cms-types]
     steps:
       - name: Checkout with full history
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6.0.2
         with:
           fetch-depth: 0
       - name: Setup
@@ -149,7 +149,7 @@ jobs:
       - name: Install dependencies for frontend
         run: pnpm --filter frontend install
       - name: Download CMS types
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8.0.1
         with:
           name: payload-types
           path: libs/payload-types/src
@@ -172,7 +172,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6.0.2
       - name: Setup
         uses: felixmokross/webplatform/.github/actions/setup@main
       - name: Install dependencies
@@ -185,7 +185,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6.0.2
       - name: Setup
         uses: felixmokross/webplatform/.github/actions/setup@main
       - name: Install dependencies
@@ -201,7 +201,7 @@ jobs:
       image: ${{ steps.image-name.outputs.image }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6.0.2
       - name: Set up flyctl
         uses: superfly/flyctl-actions/setup-flyctl@master
         with:
@@ -241,7 +241,7 @@ jobs:
       CMS_API_KEY: e2e-tests-apikey
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6.0.2
       - name: Setup
         uses: felixmokross/webplatform/.github/actions/setup@main
       - name: Install dependencies for e2e
@@ -278,7 +278,7 @@ jobs:
           echo "playwright_version=${PLAYWRIGHT_VERSION}" >> $GITHUB_OUTPUT
         working-directory: tests/e2e
       - name: Cache Playwright browsers
-        uses: actions/cache@v4
+        uses: actions/cache@v5.0.5
         id: playwright-cache
         with:
           path: ~/.cache/ms-playwright
@@ -290,7 +290,7 @@ jobs:
         if: steps.playwright-cache.outputs.cache-hit != 'true'
         working-directory: tests/e2e
       - name: Download CMS types
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8.0.1
         with:
           name: payload-types
           path: libs/payload-types/src
@@ -303,7 +303,7 @@ jobs:
           CMS_API_KEY: ${{ env.CMS_API_KEY }}
           EXPECTED_VERSION: ${{ needs.version.outputs.version }}
       - name: Upload Playwright report
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7.0.1
         if: always()
         with:
           name: playwright-report
@@ -355,7 +355,7 @@ jobs:
       contents: write
     steps:
       - name: Checkout with full history
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6.0.2
         with:
           fetch-depth: 0
       - name: Setup

--- a/.github/workflows/export.clean-preview.yml
+++ b/.github/workflows/export.clean-preview.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@v6
       - name: Set up flyctl
         uses: superfly/flyctl-actions/setup-flyctl@master
         with:

--- a/.github/workflows/export.clean-preview.yml
+++ b/.github/workflows/export.clean-preview.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6.0.2
       - name: Set up flyctl
         uses: superfly/flyctl-actions/setup-flyctl@master
         with:

--- a/.github/workflows/export.deploy-version.yml
+++ b/.github/workflows/export.deploy-version.yml
@@ -30,7 +30,7 @@ jobs:
         steps.create-app.outputs.app_name) || vars.CANONICAL_HOSTNAME }}/
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6.0.2
       - name: Set up flyctl
         uses: superfly/flyctl-actions/setup-flyctl@master
         with:
@@ -101,7 +101,7 @@ jobs:
         steps.create-app.outputs.app_name) || vars.SERVER_URL }}/
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6.0.2
       - name: Set up flyctl
         uses: superfly/flyctl-actions/setup-flyctl@master
         with:

--- a/.github/workflows/export.deploy-version.yml
+++ b/.github/workflows/export.deploy-version.yml
@@ -30,7 +30,7 @@ jobs:
         steps.create-app.outputs.app_name) || vars.CANONICAL_HOSTNAME }}/
     steps:
       - name: Checkout
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@v6
       - name: Set up flyctl
         uses: superfly/flyctl-actions/setup-flyctl@master
         with:
@@ -101,7 +101,7 @@ jobs:
         steps.create-app.outputs.app_name) || vars.SERVER_URL }}/
     steps:
       - name: Checkout
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@v6
       - name: Set up flyctl
         uses: superfly/flyctl-actions/setup-flyctl@master
         with:

--- a/.github/workflows/version.yml
+++ b/.github/workflows/version.yml
@@ -48,7 +48,7 @@ jobs:
       sha: ${{ steps.get-version.outputs.sha }}
     steps:
       - name: Checkout with full history
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
       - name: Setup

--- a/.github/workflows/version.yml
+++ b/.github/workflows/version.yml
@@ -48,7 +48,7 @@ jobs:
       sha: ${{ steps.get-version.outputs.sha }}
     steps:
       - name: Checkout with full history
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6.0.2
         with:
           fetch-depth: 0
       - name: Setup


### PR DESCRIPTION
## Summary
- upgrade selected first-party GitHub Actions references to current major-only pins
- update the shared pnpm/Node setup action to pnpm/action-setup v6 and actions/setup-node v6
- keep third-party workflow actions intentionally unchanged, including chromaui/action and superfly/flyctl-actions

## Validation
- `git grep -n "actions/checkout@v4\\|actions/upload-artifact@v4\\|actions/download-artifact@v4\\|actions/cache@v4\\|pnpm/action-setup@v4\\|actions/setup-node@v4" -- .github` returned no matches
- `git grep -n "actions/checkout@v6\\.0\\.2\\|actions/upload-artifact@v7\\.0\\.1\\|actions/download-artifact@v8\\.0\\.1\\|actions/cache@v5\\.0\\.5\\|pnpm/action-setup@v6\\.0\\.8\\|actions/setup-node@v6\\.4\\.0" -- .github` returned no matches
- `git diff --check`
- `pnpm format:check`