### PR TITLE
ci(actions): pin flyctl setup action

### DIFF
--- a/.github/workflows/export.build.yml
+++ b/.github/workflows/export.build.yml
@@ -101,7 +101,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
       - name: Set up flyctl
-        uses: superfly/flyctl-actions/setup-flyctl@master
+        uses: superfly/flyctl-actions/setup-flyctl@v1
         with:
           version: ${{ env.FLYCTL_VERSION }}
       - name: Setup
@@ -203,7 +203,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
       - name: Set up flyctl
-        uses: superfly/flyctl-actions/setup-flyctl@master
+        uses: superfly/flyctl-actions/setup-flyctl@v1
         with:
           version: ${{ env.FLYCTL_VERSION }}
       - name: Setup
@@ -247,7 +247,7 @@ jobs:
       - name: Install dependencies for e2e
         run: pnpm --filter e2e install
       - name: Set up flyctl
-        uses: superfly/flyctl-actions/setup-flyctl@master
+        uses: superfly/flyctl-actions/setup-flyctl@v1
         with:
           version: ${{ env.FLYCTL_VERSION }}
       - name: Authenticate Fly.io Docker registry

--- a/.github/workflows/export.clean-preview.yml
+++ b/.github/workflows/export.clean-preview.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
       - name: Set up flyctl
-        uses: superfly/flyctl-actions/setup-flyctl@master
+        uses: superfly/flyctl-actions/setup-flyctl@v1
         with:
           version: ${{ env.FLYCTL_VERSION }}
       - name: Clean up old preview apps

--- a/.github/workflows/export.deploy-version.yml
+++ b/.github/workflows/export.deploy-version.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
       - name: Set up flyctl
-        uses: superfly/flyctl-actions/setup-flyctl@master
+        uses: superfly/flyctl-actions/setup-flyctl@v1
         with:
           version: ${{ env.FLYCTL_VERSION }}
       - name: Create app
@@ -103,7 +103,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
       - name: Set up flyctl
-        uses: superfly/flyctl-actions/setup-flyctl@master
+        uses: superfly/flyctl-actions/setup-flyctl@v1
         with:
           version: ${{ env.FLYCTL_VERSION }}
       - name: Create app


### PR DESCRIPTION
## Summary
- pin Superfly setup-flyctl action refs to the v1 major tag across export workflows
- keep the existing FLYCTL_VERSION input so flyctl still installs version 0.4.52
- leave chromaui/action@v1 unchanged so the Chromatic major upgrade can be reviewed separately

## Validation
- rg -n "superfly/flyctl-actions/setup-flyctl@master|superfly/flyctl-actions/setup-flyctl@v1\.4" .github/workflows
- rg -n "superfly/flyctl-actions/setup-flyctl@v1$|chromaui/action@v1" .github/workflows
- git diff --check
- source "$HOME/.nvm/nvm.sh" && nvm use 24 >/dev/null && pnpm format:check