### PR TITLE
ci: upgrade Chromatic action to v17

### DIFF
--- a/.github/workflows/export.build.yml
+++ b/.github/workflows/export.build.yml
@@ -154,7 +154,7 @@ jobs:
           name: payload-types
           path: libs/payload-types/src
       - name: Publish frontend to Chromatic
-        uses: chromaui/action@v1
+        uses: chromaui/action@v17
         with:
           projectToken: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
           exitOnceUploaded: true


### PR DESCRIPTION
## Summary
- Upgrade the Chromatic GitHub Action from v1 to v17.
- Keep existing Chromatic configuration unchanged.

## Verification
- `pnpm exec prettier --check .github/workflows/export.build.yml`
