### PR TITLE
fix(deploy): wait for Fly registry images before deploy

### DIFF
--- a/.github/workflows/export.deploy-version.yml
+++ b/.github/workflows/export.deploy-version.yml
@@ -20,9 +20,65 @@ env:
   FRONTEND_INTERNAL_PORT: 3000
 
 jobs:
+  images-ready:
+    name: "Images: Ready"
+    runs-on: ubuntu-latest
+    steps:
+      - name: Log in to Fly registry
+        uses: docker/login-action@v4
+        with:
+          registry: registry.fly.io
+          username: x
+          password: ${{ secrets.FLY_API_TOKEN }}
+      - name: Wait for Fly registry images
+        run: |
+          set -euo pipefail
+
+          IMAGES=(
+            "registry.fly.io/${{ vars.FLY_STAGING_FRONTEND_APP }}:v${{ inputs.version_with_sha }}"
+            "registry.fly.io/${{ vars.FLY_STAGING_CMS_APP }}:v${{ inputs.version_with_sha }}"
+          )
+          MAX_ATTEMPTS=24
+          SLEEP_SECONDS=15
+
+          for IMAGE in "${IMAGES[@]}"; do
+            LAST_ERROR=""
+
+            for attempt in $(seq 1 "$MAX_ATTEMPTS"); do
+              ERROR_FILE="$(mktemp)"
+              if timeout 20s docker manifest inspect "$IMAGE" > /dev/null 2>"$ERROR_FILE"; then
+                rm -f "$ERROR_FILE"
+                echo "Image is available: $IMAGE"
+                break
+              fi
+
+              ERROR_TEXT="$(tr '\n' ' ' < "$ERROR_FILE" | sed -E 's/[[:space:]]+/ /g')"
+              rm -f "$ERROR_FILE"
+              LAST_ERROR="$ERROR_TEXT"
+
+              if printf '%s' "$ERROR_TEXT" | grep -Eiq '(unauthorized|authentication required|denied|forbidden|insufficient_scope|access denied)'; then
+                echo "Registry auth/permission error while checking image: $IMAGE"
+                echo "docker manifest inspect error: $ERROR_TEXT"
+                exit 1
+              fi
+
+              if [ "$attempt" -lt "$MAX_ATTEMPTS" ]; then
+                echo "[$attempt/$MAX_ATTEMPTS] Waiting for image: $IMAGE"
+                sleep "$SLEEP_SECONDS"
+              else
+                echo "Timed out waiting for image: $IMAGE"
+                if [ -n "$LAST_ERROR" ]; then
+                  echo "Last docker manifest inspect error: $LAST_ERROR"
+                fi
+                exit 1
+              fi
+            done
+          done
+
   frontend-deploy:
     name: "Frontend: Deploy"
     runs-on: ubuntu-latest
+    needs: images-ready
     environment:
       name: ${{ inputs.environment }}-frontend
       url:
@@ -94,6 +150,7 @@ jobs:
   cms-deploy:
     name: "CMS: Deploy"
     runs-on: ubuntu-latest
+    needs: images-ready
     environment:
       name: ${{ inputs.environment }}-cms
       url:


### PR DESCRIPTION
## Summary
- add a shared image readiness gate before Fly deploy jobs
- log in to the Fly registry and poll frontend/CMS image manifests before deploy starts
- make frontend and CMS deploy jobs wait for that gate so preview deployments do not race registry propagation

## Validation
- `actionlint .github/workflows/export.deploy-version.yml` using a temporary downloaded actionlint binary
- `git diff --check`
- `npm_config_cache=/private/tmp/npm-cache npx --yes prettier@3.8.3 --check .github/workflows/export.deploy-version.yml`

## Notes
- This lives in the shared webplatform workflow, so lapuertahostels inherits the fix through its existing workflow calls.