### PR TITLE
feat(cms-plugin): add brand root path

### DIFF
--- a/examples/cms-example/src/payload-types.ts
+++ b/examples/cms-example/src/payload-types.ts
@@ -77,6 +77,7 @@ export interface Config {
     pages: Page;
     redirects: Redirect;
     brands: Brand;
+    'payload-kv': PayloadKv;
     'payload-locked-documents': PayloadLockedDocument;
     'payload-preferences': PayloadPreference;
     'payload-migrations': PayloadMigration;
@@ -96,6 +97,7 @@ export interface Config {
     pages: PagesSelect<false> | PagesSelect<true>;
     redirects: RedirectsSelect<false> | RedirectsSelect<true>;
     brands: BrandsSelect<false> | BrandsSelect<true>;
+    'payload-kv': PayloadKvSelect<false> | PayloadKvSelect<true>;
     'payload-locked-documents': PayloadLockedDocumentsSelect<false> | PayloadLockedDocumentsSelect<true>;
     'payload-preferences': PayloadPreferencesSelect<false> | PayloadPreferencesSelect<true>;
     'payload-migrations': PayloadMigrationsSelect<false> | PayloadMigrationsSelect<true>;
@@ -103,6 +105,294 @@ export interface Config {
   db: {
     defaultIDType: string;
   };
+  fallbackLocale:
+    | ('false' | 'none' | 'null')
+    | false
+    | null
+    | (
+        | 'en'
+        | 'en-US'
+        | 'en-GB'
+        | 'en-CA'
+        | 'en-AU'
+        | 'zh'
+        | 'zh-CN'
+        | 'zh-TW'
+        | 'zh-HK'
+        | 'es'
+        | 'es-ES'
+        | 'es-MX'
+        | 'es-AR'
+        | 'es-CO'
+        | 'es-CL'
+        | 'ar'
+        | 'ar-SA'
+        | 'ar-EG'
+        | 'ar-AE'
+        | 'pt'
+        | 'pt-BR'
+        | 'pt-PT'
+        | 'fr'
+        | 'fr-FR'
+        | 'fr-CA'
+        | 'de'
+        | 'de-DE'
+        | 'ja'
+        | 'ja-JP'
+        | 'ru'
+        | 'ru-RU'
+        | 'hi'
+        | 'hi-IN'
+        | 'it'
+        | 'it-IT'
+        | 'ko'
+        | 'ko-KR'
+        | 'tr'
+        | 'tr-TR'
+        | 'pl'
+        | 'pl-PL'
+        | 'nl'
+        | 'nl-NL'
+        | 'sv'
+        | 'sv-SE'
+        | 'fi'
+        | 'fi-FI'
+        | 'no'
+        | 'no-NO'
+        | 'da'
+        | 'da-DK'
+        | 'id'
+        | 'id-ID'
+        | 'ms'
+        | 'ms-MY'
+        | 'th'
+        | 'th-TH'
+        | 'vi'
+        | 'vi-VN'
+        | 'he'
+        | 'he-IL'
+        | 'fa'
+        | 'fa-IR'
+        | 'uk'
+        | 'uk-UA'
+        | 'cs'
+        | 'cs-CZ'
+        | 'sk'
+        | 'sk-SK'
+        | 'ro'
+        | 'ro-RO'
+        | 'hu'
+        | 'hu-HU'
+        | 'el'
+        | 'el-GR'
+        | 'bn'
+        | 'bn-BD'
+        | 'bn-IN'
+        | 'ta'
+        | 'ta-IN'
+        | 'te'
+        | 'te-IN'
+        | 'ml'
+        | 'ml-IN'
+        | 'mr'
+        | 'mr-IN'
+        | 'pa'
+        | 'pa-IN'
+        | 'gu'
+        | 'gu-IN'
+        | 'ur'
+        | 'ur-PK'
+        | 'sw'
+        | 'sw-KE'
+        | 'af'
+        | 'af-ZA'
+        | 'am'
+        | 'am-ET'
+        | 'et'
+        | 'et-EE'
+        | 'lv'
+        | 'lv-LV'
+        | 'lt'
+        | 'lt-LT'
+        | 'sl'
+        | 'sl-SI'
+        | 'sr'
+        | 'sr-RS'
+        | 'hr'
+        | 'hr-HR'
+        | 'bg'
+        | 'bg-BG'
+        | 'ka'
+        | 'ka-GE'
+        | 'az'
+        | 'az-AZ'
+        | 'hy'
+        | 'hy-AM'
+        | 'ne'
+        | 'ne-NP'
+        | 'si'
+        | 'si-LK'
+        | 'my'
+        | 'my-MM'
+        | 'km'
+        | 'km-KH'
+        | 'lo'
+        | 'lo-LA'
+        | 'mn'
+        | 'mn-MN'
+        | 'kk'
+        | 'kk-KZ'
+        | 'uz'
+        | 'uz-UZ'
+        | 'ps'
+        | 'ps-AF'
+        | 'es-419'
+        | 'zh-Hans'
+        | 'zh-Hant'
+        | 'nb'
+      )
+    | (
+        | 'en'
+        | 'en-US'
+        | 'en-GB'
+        | 'en-CA'
+        | 'en-AU'
+        | 'zh'
+        | 'zh-CN'
+        | 'zh-TW'
+        | 'zh-HK'
+        | 'es'
+        | 'es-ES'
+        | 'es-MX'
+        | 'es-AR'
+        | 'es-CO'
+        | 'es-CL'
+        | 'ar'
+        | 'ar-SA'
+        | 'ar-EG'
+        | 'ar-AE'
+        | 'pt'
+        | 'pt-BR'
+        | 'pt-PT'
+        | 'fr'
+        | 'fr-FR'
+        | 'fr-CA'
+        | 'de'
+        | 'de-DE'
+        | 'ja'
+        | 'ja-JP'
+        | 'ru'
+        | 'ru-RU'
+        | 'hi'
+        | 'hi-IN'
+        | 'it'
+        | 'it-IT'
+        | 'ko'
+        | 'ko-KR'
+        | 'tr'
+        | 'tr-TR'
+        | 'pl'
+        | 'pl-PL'
+        | 'nl'
+        | 'nl-NL'
+        | 'sv'
+        | 'sv-SE'
+        | 'fi'
+        | 'fi-FI'
+        | 'no'
+        | 'no-NO'
+        | 'da'
+        | 'da-DK'
+        | 'id'
+        | 'id-ID'
+        | 'ms'
+        | 'ms-MY'
+        | 'th'
+        | 'th-TH'
+        | 'vi'
+        | 'vi-VN'
+        | 'he'
+        | 'he-IL'
+        | 'fa'
+        | 'fa-IR'
+        | 'uk'
+        | 'uk-UA'
+        | 'cs'
+        | 'cs-CZ'
+        | 'sk'
+        | 'sk-SK'
+        | 'ro'
+        | 'ro-RO'
+        | 'hu'
+        | 'hu-HU'
+        | 'el'
+        | 'el-GR'
+        | 'bn'
+        | 'bn-BD'
+        | 'bn-IN'
+        | 'ta'
+        | 'ta-IN'
+        | 'te'
+        | 'te-IN'
+        | 'ml'
+        | 'ml-IN'
+        | 'mr'
+        | 'mr-IN'
+        | 'pa'
+        | 'pa-IN'
+        | 'gu'
+        | 'gu-IN'
+        | 'ur'
+        | 'ur-PK'
+        | 'sw'
+        | 'sw-KE'
+        | 'af'
+        | 'af-ZA'
+        | 'am'
+        | 'am-ET'
+        | 'et'
+        | 'et-EE'
+        | 'lv'
+        | 'lv-LV'
+        | 'lt'
+        | 'lt-LT'
+        | 'sl'
+        | 'sl-SI'
+        | 'sr'
+        | 'sr-RS'
+        | 'hr'
+        | 'hr-HR'
+        | 'bg'
+        | 'bg-BG'
+        | 'ka'
+        | 'ka-GE'
+        | 'az'
+        | 'az-AZ'
+        | 'hy'
+        | 'hy-AM'
+        | 'ne'
+        | 'ne-NP'
+        | 'si'
+        | 'si-LK'
+        | 'my'
+        | 'my-MM'
+        | 'km'
+        | 'km-KH'
+        | 'lo'
+        | 'lo-LA'
+        | 'mn'
+        | 'mn-MN'
+        | 'kk'
+        | 'kk-KZ'
+        | 'uz'
+        | 'uz-UZ'
+        | 'ps'
+        | 'ps-AF'
+        | 'es-419'
+        | 'zh-Hans'
+        | 'zh-Hant'
+        | 'nb'
+      )[];
   globals: {
     settings: Settings;
     common: Common;
@@ -252,13 +542,10 @@ export interface Config {
     | 'zh-Hans'
     | 'zh-Hant'
     | 'nb';
-  user:
-    | (User & {
-        collection: 'users';
-      })
-    | (ApiKey & {
-        collection: 'api-keys';
-      });
+  widgets: {
+    collections: CollectionsWidget;
+  };
+  user: User | ApiKey;
   jobs: {
     tasks: unknown;
     workflows: unknown;
@@ -370,6 +657,7 @@ export interface User {
       }[]
     | null;
   password?: string | null;
+  collection: 'users';
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema
@@ -384,6 +672,7 @@ export interface ApiKey {
   enableAPIKey?: boolean | null;
   apiKey?: string | null;
   apiKeyIndex?: string | null;
+  collection: 'api-keys';
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema
@@ -754,7 +1043,7 @@ export interface Page {
    */
   brand: string | Brand;
   /**
-   * The pathname is used to navigate to this page. It must be unique. The first path segment must be the brand's home link.
+   * The pathname is used to navigate to this page. It must be unique and start with the brand's root path.
    */
   pathname: string;
   pathname_locked?: boolean | null;
@@ -790,7 +1079,7 @@ export interface HeroSlides {
         root: {
           type: string;
           children: {
-            type: string;
+            type: any;
             version: number;
             [k: string]: unknown;
           }[];
@@ -805,7 +1094,7 @@ export interface HeroSlides {
         root: {
           type: string;
           children: {
-            type: string;
+            type: any;
             version: number;
             [k: string]: unknown;
           }[];
@@ -857,7 +1146,7 @@ export interface HeroVideo {
       root: {
         type: string;
         children: {
-          type: string;
+          type: any;
           version: number;
           [k: string]: unknown;
         }[];
@@ -872,7 +1161,7 @@ export interface HeroVideo {
       root: {
         type: string;
         children: {
-          type: string;
+          type: any;
           version: number;
           [k: string]: unknown;
         }[];
@@ -920,7 +1209,7 @@ export interface LeadText {
     root: {
       type: string;
       children: {
-        type: string;
+        type: any;
         version: number;
         [k: string]: unknown;
       }[];
@@ -953,7 +1242,7 @@ export interface ImageWithFloatingText {
       root: {
         type: string;
         children: {
-          type: string;
+          type: any;
           version: number;
           [k: string]: unknown;
         }[];
@@ -974,7 +1263,7 @@ export interface ImageWithFloatingText {
     root: {
       type: string;
       children: {
-        type: string;
+        type: any;
         version: number;
         [k: string]: unknown;
       }[];
@@ -1000,7 +1289,7 @@ export interface Story {
     root: {
       type: string;
       children: {
-        type: string;
+        type: any;
         version: number;
         [k: string]: unknown;
       }[];
@@ -1035,7 +1324,7 @@ export interface Features {
       root: {
         type: string;
         children: {
-          type: string;
+          type: any;
           version: number;
           [k: string]: unknown;
         }[];
@@ -1081,7 +1370,7 @@ export interface WideImage {
       root: {
         type: string;
         children: {
-          type: string;
+          type: any;
           version: number;
           [k: string]: unknown;
         }[];
@@ -1114,7 +1403,7 @@ export interface TextColumnsWithImages {
     root: {
       type: string;
       children: {
-        type: string;
+        type: any;
         version: number;
         [k: string]: unknown;
       }[];
@@ -1137,7 +1426,7 @@ export interface TextColumnsWithImages {
       root: {
         type: string;
         children: {
-          type: string;
+          type: any;
           version: number;
           [k: string]: unknown;
         }[];
@@ -1180,7 +1469,7 @@ export interface Map {
       root: {
         type: string;
         children: {
-          type: string;
+          type: any;
           version: number;
           [k: string]: unknown;
         }[];
@@ -1209,7 +1498,7 @@ export interface Testimonials {
     root: {
       type: string;
       children: {
-        type: string;
+        type: any;
         version: number;
         [k: string]: unknown;
       }[];
@@ -1242,7 +1531,7 @@ export interface RoomList {
       root: {
         type: string;
         children: {
-          type: string;
+          type: any;
           version: number;
           [k: string]: unknown;
         }[];
@@ -1277,6 +1566,10 @@ export interface Brand {
   id: string;
   name: string;
   homeLink?: NewLink;
+  /**
+   * The localized root path for this brand. Pages for this brand must use this path or a child path below it.
+   */
+  rootPath: string;
   /**
    * The base title is appended to the titles of the brand’s pages. If the page does not have a title, the base title will be used as the title. Include important keywords in the title for SEO.
    */
@@ -1330,6 +1623,23 @@ export interface Redirect {
   };
   updatedAt: string;
   createdAt: string;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "payload-kv".
+ */
+export interface PayloadKv {
+  id: string;
+  key: string;
+  data:
+    | {
+        [k: string]: unknown;
+      }
+    | unknown[]
+    | string
+    | number
+    | boolean
+    | null;
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema
@@ -1886,6 +2196,7 @@ export interface BrandsSelect<T extends boolean = true> {
   id?: T;
   name?: T;
   homeLink?: T | NewLinkSelect<T>;
+  rootPath?: T;
   baseTitle?: T;
   logo?: T;
   banner?: T;
@@ -1922,6 +2233,14 @@ export interface BrandsSelect<T extends boolean = true> {
       };
   updatedAt?: T;
   createdAt?: T;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "payload-kv_select".
+ */
+export interface PayloadKvSelect<T extends boolean = true> {
+  key?: T;
+  data?: T;
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema
@@ -2003,7 +2322,7 @@ export interface Common {
       root: {
         type: string;
         children: {
-          type: string;
+          type: any;
           version: number;
           [k: string]: unknown;
         }[];
@@ -2021,7 +2340,7 @@ export interface Common {
       root: {
         type: string;
         children: {
-          type: string;
+          type: any;
           version: number;
           [k: string]: unknown;
         }[];
@@ -2140,6 +2459,16 @@ export interface CommonSelect<T extends boolean = true> {
   updatedAt?: T;
   createdAt?: T;
   globalType?: T;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "collections_widget".
+ */
+export interface CollectionsWidget {
+  data?: {
+    [k: string]: unknown;
+  };
+  width: 'full';
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema

--- a/libs/cms-plugin/README.md
+++ b/libs/cms-plugin/README.md
@@ -2,6 +2,19 @@
 
 A template repo to create a [Payload CMS](https://payloadcms.com) plugin.
 
+## Brand URL Model
+
+Brands own their URL namespace through the localized `rootPath` field. Use
+`rootPath` as the preferred public API for brand routing and URL-prefix logic.
+Every page assigned to a brand must use either the brand's root path itself or a
+child path below it.
+
+The `homeLink` field is kept for backwards compatibility with existing API
+consumers. It is hidden from editors and managed by the plugin: when a page's
+localized pathname matches the brand's localized `rootPath`, that page becomes
+the derived home link. New consumers should not treat `homeLink` as the source
+of truth for a brand's URL prefix.
+
 Payload is built with a robust infrastructure intended to support Plugins with
 ease. This provides a simple, modular, and reusable way for developers to extend
 the core capabilities of Payload.

--- a/libs/cms-plugin/src/collections/brands/config.ts
+++ b/libs/cms-plugin/src/collections/brands/config.ts
@@ -1,19 +1,30 @@
+import type { TFunction } from "@payloadcms/translations";
 import type {
   CollectionConfig,
   Locale,
-  Payload,
   SanitizedCollectionConfig,
+  TextField,
+  ValidateOptions,
 } from "payload";
 
+import { text } from "payload/shared";
+
 import type { RowLabelProps } from "../../components/client/row-label.js";
+import type { TranslationsKey } from "../../translations/types.js";
 
 import { canManageContent, isAdmin } from "../../common/access-control.js";
 import { getLivePreviewUrl } from "../../common/live-preview.js";
+import {
+  normalizePathnameInput,
+  validateRootPathFormat,
+} from "../../common/pathname.js";
 import { imageField } from "../../fields/image.js";
 import { linkField } from "../../fields/link.js";
 import { showField } from "../../fields/show.js";
 import { textField } from "../../fields/text.js";
 import { contentGroup } from "../../groups.js";
+import { syncBrandHomeLink } from "./home-link.js";
+import { getBrandsForRootPath } from "./root-path.js";
 import { brandUsagesField } from "./usages.js";
 
 type BrandsOptions = {
@@ -31,29 +42,22 @@ export function Brands({
       update: canManageContent,
     },
     admin: {
-      defaultColumns: ["name", "logo", "homeLink", "updatedAt"],
+      defaultColumns: ["name", "rootPath", "logo", "updatedAt"],
       group: contentGroup,
       listSearchableFields: ["id", "name"],
       livePreview: livePreviewBaseUrl
         ? {
-            url: async ({
+            url: ({
               data,
               locale,
-              payload,
             }: {
               collectionConfig?: SanitizedCollectionConfig;
               data: Record<string, unknown>;
               locale: Locale;
-              payload: Payload;
             }) => {
-              const homePage = await payload.findByID({
-                id: (data.homeLink as { doc: string }).doc,
-                collection: "pages",
-              });
-
               return getLivePreviewUrl(
                 livePreviewBaseUrl,
-                homePage.pathname,
+                typeof data.rootPath === "string" ? data.rootPath : "/",
                 `brands/${data.id as string}`,
                 locale.code,
               );
@@ -67,6 +71,7 @@ export function Brands({
       name: true,
       baseTitle: true,
       homeLink: true,
+      rootPath: true,
     },
     defaultSort: "name",
     fields: [
@@ -111,12 +116,76 @@ export function Brands({
                     create: () => false,
                     update: () => false,
                   },
+                  admin: {
+                    hidden: true,
+                  },
                   label: {
                     en: "Home Link",
                     es: "Enlace de inicio",
                   },
                 },
                 required: false,
+              }),
+              textField({
+                name: "rootPath",
+                admin: {
+                  description: {
+                    en: "The localized root path for this brand. Pages for this brand must use this path or a child path below it.",
+                    es: "La ruta raíz localizada de esta marca. Las páginas de esta marca deben usar esta ruta o una ruta hija dentro de ella.",
+                  },
+                  placeholder: "e.g. /brand-name",
+                },
+                hooks: {
+                  beforeValidate: [
+                    ({ value }) =>
+                      typeof value === "string"
+                        ? normalizePathnameInput(value)
+                        : value,
+                  ],
+                },
+                label: {
+                  en: "Root Path",
+                  es: "Ruta raíz",
+                },
+                validate: async (
+                  value: null | string | undefined,
+                  options: ValidateOptions<
+                    Record<string, unknown>,
+                    Record<string, unknown>,
+                    TextField,
+                    string
+                  >,
+                ) => {
+                  const defaultValidationResult = text(value, options);
+                  if (defaultValidationResult !== true) {
+                    return defaultValidationResult;
+                  }
+
+                  const t = options.req
+                    .t as unknown as TFunction<TranslationsKey>;
+                  const rootPath = normalizePathnameInput(value ?? "");
+                  const formatValidationResult =
+                    validateRootPathFormat(rootPath);
+
+                  if (formatValidationResult !== true) {
+                    return t(
+                      `cmsPlugin:brands:rootPath:${formatValidationResult}`,
+                    );
+                  }
+
+                  const brands = await getBrandsForRootPath(
+                    options.req,
+                    rootPath,
+                  );
+                  const alreadyExists = brands.some(
+                    (brand) => brand.id !== options.id,
+                  );
+                  if (alreadyExists) {
+                    return t("cmsPlugin:brands:rootPath:alreadyExists");
+                  }
+
+                  return true;
+                },
               }),
               textField({
                 name: "baseTitle",
@@ -322,6 +391,21 @@ export function Brands({
         ],
       },
     ],
+    hooks: {
+      afterChange: [
+        async ({ doc, operation, previousDoc, req }) => {
+          if (operation !== "update") {
+            return;
+          }
+
+          if (doc.rootPath === previousDoc?.rootPath) {
+            return;
+          }
+
+          await syncBrandHomeLink({ brandId: doc.id as string, req });
+        },
+      ],
+    },
     labels: {
       plural: {
         en: "Brands",

--- a/libs/cms-plugin/src/collections/brands/config.ts
+++ b/libs/cms-plugin/src/collections/brands/config.ts
@@ -1,30 +1,20 @@
-import type { TFunction } from "@payloadcms/translations";
 import type {
   CollectionConfig,
   Locale,
   SanitizedCollectionConfig,
-  TextField,
-  ValidateOptions,
 } from "payload";
 
-import { text } from "payload/shared";
-
 import type { RowLabelProps } from "../../components/client/row-label.js";
-import type { TranslationsKey } from "../../translations/types.js";
 
 import { canManageContent, isAdmin } from "../../common/access-control.js";
 import { getLivePreviewUrl } from "../../common/live-preview.js";
-import {
-  normalizePathnameInput,
-  validateRootPathFormat,
-} from "../../common/pathname.js";
 import { imageField } from "../../fields/image.js";
 import { linkField } from "../../fields/link.js";
 import { showField } from "../../fields/show.js";
 import { textField } from "../../fields/text.js";
 import { contentGroup } from "../../groups.js";
 import { syncBrandHomeLink } from "./home-link.js";
-import { getBrandsForRootPath } from "./root-path.js";
+import { rootPathField } from "./root-path.js";
 import { brandUsagesField } from "./usages.js";
 
 type BrandsOptions = {
@@ -126,67 +116,7 @@ export function Brands({
                 },
                 required: false,
               }),
-              textField({
-                name: "rootPath",
-                admin: {
-                  description: {
-                    en: "The localized root path for this brand. Pages for this brand must use this path or a child path below it.",
-                    es: "La ruta raíz localizada de esta marca. Las páginas de esta marca deben usar esta ruta o una ruta hija dentro de ella.",
-                  },
-                  placeholder: "e.g. /brand-name",
-                },
-                hooks: {
-                  beforeValidate: [
-                    ({ value }) =>
-                      typeof value === "string"
-                        ? normalizePathnameInput(value)
-                        : value,
-                  ],
-                },
-                label: {
-                  en: "Root Path",
-                  es: "Ruta raíz",
-                },
-                validate: async (
-                  value: null | string | undefined,
-                  options: ValidateOptions<
-                    Record<string, unknown>,
-                    Record<string, unknown>,
-                    TextField,
-                    string
-                  >,
-                ) => {
-                  const defaultValidationResult = text(value, options);
-                  if (defaultValidationResult !== true) {
-                    return defaultValidationResult;
-                  }
-
-                  const t = options.req
-                    .t as unknown as TFunction<TranslationsKey>;
-                  const rootPath = normalizePathnameInput(value ?? "");
-                  const formatValidationResult =
-                    validateRootPathFormat(rootPath);
-
-                  if (formatValidationResult !== true) {
-                    return t(
-                      `cmsPlugin:brands:rootPath:${formatValidationResult}`,
-                    );
-                  }
-
-                  const brands = await getBrandsForRootPath(
-                    options.req,
-                    rootPath,
-                  );
-                  const alreadyExists = brands.some(
-                    (brand) => brand.id !== options.id,
-                  );
-                  if (alreadyExists) {
-                    return t("cmsPlugin:brands:rootPath:alreadyExists");
-                  }
-
-                  return true;
-                },
-              }),
+              rootPathField(),
               textField({
                 name: "baseTitle",
                 admin: {

--- a/libs/cms-plugin/src/collections/brands/config.ts
+++ b/libs/cms-plugin/src/collections/brands/config.ts
@@ -328,7 +328,10 @@ export function Brands({
             return;
           }
 
-          if (doc.rootPath === previousDoc?.rootPath) {
+          if (
+            JSON.stringify(doc.rootPath) ===
+            JSON.stringify(previousDoc?.rootPath)
+          ) {
             return;
           }
 

--- a/libs/cms-plugin/src/collections/brands/home-link.ts
+++ b/libs/cms-plugin/src/collections/brands/home-link.ts
@@ -1,0 +1,75 @@
+import type { PayloadRequest } from "payload";
+
+function getRelationshipId(value: unknown) {
+  if (typeof value === "string") {
+    return value;
+  }
+
+  if (
+    value &&
+    typeof value === "object" &&
+    "id" in value &&
+    typeof value.id === "string"
+  ) {
+    return value.id;
+  }
+
+  return undefined;
+}
+
+export function getPageBrandId(page: Record<string, unknown>) {
+  return getRelationshipId(page.brand);
+}
+
+export async function syncBrandHomeLink({
+  brandId,
+  req,
+}: {
+  brandId: string;
+  req: PayloadRequest;
+}) {
+  const brand = await req.payload.findByID({
+    id: brandId,
+    collection: "brands",
+    req,
+    select: {
+      rootPath: true,
+    },
+  });
+
+  if (typeof brand.rootPath !== "string") {
+    return;
+  }
+
+  const pathnameWhere = req.locale
+    ? { [`pathname.${req.locale}`]: { equals: brand.rootPath } }
+    : { pathname: { equals: brand.rootPath } };
+
+  const homePages = await req.payload.find({
+    collection: "pages",
+    depth: 0,
+    limit: 1,
+    pagination: false,
+    req,
+    where: {
+      and: [{ brand: { equals: brandId } }, pathnameWhere],
+    },
+  });
+
+  const homePage = homePages.docs[0];
+
+  await req.payload.update({
+    id: brandId,
+    collection: "brands",
+    data: {
+      homeLink: homePage
+        ? {
+            doc: homePage.id,
+            linkType: "internal",
+          }
+        : {},
+    },
+    overrideAccess: true,
+    req,
+  });
+}

--- a/libs/cms-plugin/src/collections/brands/home-link.ts
+++ b/libs/cms-plugin/src/collections/brands/home-link.ts
@@ -1,5 +1,7 @@
 import type { PayloadRequest } from "payload";
 
+import { getPublishedLocaleIds } from "./root-path.js";
+
 function getRelationshipId(value: unknown) {
   if (typeof value === "string") {
     return value;
@@ -31,19 +33,21 @@ export async function syncBrandHomeLink({
   const brand = await req.payload.findByID({
     id: brandId,
     collection: "brands",
+    locale: "all",
     req,
     select: {
       rootPath: true,
     },
   });
 
-  if (typeof brand.rootPath !== "string") {
+  const rootPathsByLocale = getRootPathsByLocale(
+    brand.rootPath,
+    await getPublishedLocaleIds(req),
+  );
+
+  if (rootPathsByLocale.length === 0) {
     return;
   }
-
-  const pathnameWhere = req.locale
-    ? { [`pathname.${req.locale}`]: { equals: brand.rootPath } }
-    : { pathname: { equals: brand.rootPath } };
 
   const homePages = await req.payload.find({
     collection: "pages",
@@ -52,7 +56,14 @@ export async function syncBrandHomeLink({
     pagination: false,
     req,
     where: {
-      and: [{ brand: { equals: brandId } }, pathnameWhere],
+      and: [
+        { brand: { equals: brandId } },
+        {
+          or: rootPathsByLocale.map(({ localeId, rootPath }) => ({
+            [`pathname.${localeId}`]: { equals: rootPath },
+          })),
+        },
+      ],
     },
   });
 
@@ -71,5 +82,23 @@ export async function syncBrandHomeLink({
     },
     overrideAccess: true,
     req,
+  });
+}
+
+export function getRootPathsByLocale(rootPath: unknown, localeIds: string[]) {
+  if (typeof rootPath === "string") {
+    return localeIds.map((localeId) => ({ localeId, rootPath }));
+  }
+
+  if (!rootPath || typeof rootPath !== "object" || Array.isArray(rootPath)) {
+    return [];
+  }
+
+  return localeIds.flatMap((localeId) => {
+    const localizedRootPath = (rootPath as Record<string, unknown>)[localeId];
+
+    return typeof localizedRootPath === "string"
+      ? [{ localeId, rootPath: localizedRootPath }]
+      : [];
   });
 }

--- a/libs/cms-plugin/src/collections/brands/root-path.ts
+++ b/libs/cms-plugin/src/collections/brands/root-path.ts
@@ -7,6 +7,7 @@ import type { TranslationsKey } from "../../translations/types.js";
 
 import {
   normalizePathnameInput,
+  pathnameBelongsToRootPath,
   validateRootPathFormat,
 } from "../../common/pathname.js";
 import { textField } from "../../fields/text.js";
@@ -57,16 +58,17 @@ async function validateRootPath(
     return t(`cmsPlugin:brands:rootPath:${formatValidationResult}`);
   }
 
-  const brands = await getBrandsForRootPath(options.req, rootPath);
-  const alreadyExists = brands.some((brand) => brand.id !== options.id);
-  if (alreadyExists) {
-    return t("cmsPlugin:brands:rootPath:alreadyExists");
+  const overlappingBrand = (
+    await getBrandsWithOverlappingRootPath(options.req, rootPath)
+  ).find((brand) => brand.id !== options.id);
+  if (overlappingBrand) {
+    return t("cmsPlugin:brands:rootPath:overlaps");
   }
 
   return true;
 }
 
-export async function getBrandsForRootPath(
+export async function getBrandsWithOverlappingRootPath(
   req: PayloadRequest,
   rootPath: string,
 ) {
@@ -74,16 +76,42 @@ export async function getBrandsForRootPath(
 
   const result = await req.payload.find({
     collection: "brands",
+    locale: "all",
     pagination: false,
     req,
-    where: {
-      or: publishedLocaleIds.map((localeId) => ({
-        [`rootPath.${localeId}`]: { equals: rootPath },
-      })),
+    select: {
+      rootPath: true,
     },
   });
 
-  return result.docs;
+  return result.docs.filter((brand) =>
+    getLocalizedRootPaths(brand.rootPath, publishedLocaleIds).some(
+      (existingRootPath) => rootPathsOverlap(existingRootPath, rootPath),
+    ),
+  );
+}
+
+export function rootPathsOverlap(rootPathA: string, rootPathB: string) {
+  return (
+    pathnameBelongsToRootPath(rootPathA, rootPathB) ||
+    pathnameBelongsToRootPath(rootPathB, rootPathA)
+  );
+}
+
+function getLocalizedRootPaths(rootPath: unknown, localeIds: string[]) {
+  if (typeof rootPath === "string") {
+    return [rootPath];
+  }
+
+  if (!rootPath || typeof rootPath !== "object" || Array.isArray(rootPath)) {
+    return [];
+  }
+
+  return localeIds.flatMap((localeId) => {
+    const localizedRootPath = (rootPath as Record<string, unknown>)[localeId];
+
+    return typeof localizedRootPath === "string" ? [localizedRootPath] : [];
+  });
 }
 
 export async function getPublishedLocaleIds(req: PayloadRequest) {

--- a/libs/cms-plugin/src/collections/brands/root-path.ts
+++ b/libs/cms-plugin/src/collections/brands/root-path.ts
@@ -1,4 +1,70 @@
-import type { PayloadRequest } from "payload";
+import type { TFunction } from "@payloadcms/translations";
+import type { PayloadRequest, TextField, ValidateOptions } from "payload";
+
+import { text } from "payload/shared";
+
+import type { TranslationsKey } from "../../translations/types.js";
+
+import {
+  normalizePathnameInput,
+  validateRootPathFormat,
+} from "../../common/pathname.js";
+import { textField } from "../../fields/text.js";
+
+export function rootPathField() {
+  return textField({
+    name: "rootPath",
+    admin: {
+      description: {
+        en: "The localized root path for this brand. Pages for this brand must use this path or a child path below it.",
+        es: "La ruta raíz localizada de esta marca. Las páginas de esta marca deben usar esta ruta o una ruta hija dentro de ella.",
+      },
+      placeholder: "e.g. /brand-name",
+    },
+    hooks: {
+      beforeValidate: [
+        ({ value }) =>
+          typeof value === "string" ? normalizePathnameInput(value) : value,
+      ],
+    },
+    label: {
+      en: "Root Path",
+      es: "Ruta raíz",
+    },
+    validate: validateRootPath,
+  });
+}
+
+async function validateRootPath(
+  value: null | string | undefined,
+  options: ValidateOptions<
+    Record<string, unknown>,
+    Record<string, unknown>,
+    TextField,
+    string
+  >,
+) {
+  const defaultValidationResult = text(value, options);
+  if (defaultValidationResult !== true) {
+    return defaultValidationResult;
+  }
+
+  const t = options.req.t as unknown as TFunction<TranslationsKey>;
+  const rootPath = normalizePathnameInput(value ?? "");
+  const formatValidationResult = validateRootPathFormat(rootPath);
+
+  if (formatValidationResult !== true) {
+    return t(`cmsPlugin:brands:rootPath:${formatValidationResult}`);
+  }
+
+  const brands = await getBrandsForRootPath(options.req, rootPath);
+  const alreadyExists = brands.some((brand) => brand.id !== options.id);
+  if (alreadyExists) {
+    return t("cmsPlugin:brands:rootPath:alreadyExists");
+  }
+
+  return true;
+}
 
 export async function getBrandsForRootPath(
   req: PayloadRequest,

--- a/libs/cms-plugin/src/collections/brands/root-path.ts
+++ b/libs/cms-plugin/src/collections/brands/root-path.ts
@@ -1,0 +1,32 @@
+import type { PayloadRequest } from "payload";
+
+export async function getBrandsForRootPath(
+  req: PayloadRequest,
+  rootPath: string,
+) {
+  const settings = await req.payload.findGlobal({
+    slug: "settings",
+    req,
+    select: {
+      publishedLocales: {
+        publishedLocales: true,
+      },
+    },
+  });
+
+  const result = await req.payload.find({
+    collection: "brands",
+    pagination: false,
+    req,
+    where: {
+      or: (
+        (settings.publishedLocales as Record<string, unknown>)
+          .publishedLocales as { id: string }[]
+      ).map((l) => ({
+        [`rootPath.${l.id}`]: { equals: rootPath },
+      })),
+    },
+  });
+
+  return result.docs;
+}

--- a/libs/cms-plugin/src/collections/brands/root-path.ts
+++ b/libs/cms-plugin/src/collections/brands/root-path.ts
@@ -70,6 +70,23 @@ export async function getBrandsForRootPath(
   req: PayloadRequest,
   rootPath: string,
 ) {
+  const publishedLocaleIds = await getPublishedLocaleIds(req);
+
+  const result = await req.payload.find({
+    collection: "brands",
+    pagination: false,
+    req,
+    where: {
+      or: publishedLocaleIds.map((localeId) => ({
+        [`rootPath.${localeId}`]: { equals: rootPath },
+      })),
+    },
+  });
+
+  return result.docs;
+}
+
+export async function getPublishedLocaleIds(req: PayloadRequest) {
   const settings = await req.payload.findGlobal({
     slug: "settings",
     req,
@@ -80,19 +97,11 @@ export async function getBrandsForRootPath(
     },
   });
 
-  const result = await req.payload.find({
-    collection: "brands",
-    pagination: false,
-    req,
-    where: {
-      or: (
-        (settings.publishedLocales as Record<string, unknown>)
-          .publishedLocales as { id: string }[]
-      ).map((l) => ({
-        [`rootPath.${l.id}`]: { equals: rootPath },
-      })),
-    },
-  });
+  const publishedLocales = (
+    settings.publishedLocales as Record<string, unknown>
+  ).publishedLocales as ({ id: string } | string)[];
 
-  return result.docs;
+  return publishedLocales
+    .map((locale) => (typeof locale === "string" ? locale : locale.id))
+    .filter((localeId): localeId is string => Boolean(localeId));
 }

--- a/libs/cms-plugin/src/collections/pages/config.ts
+++ b/libs/cms-plugin/src/collections/pages/config.ts
@@ -15,12 +15,14 @@ import type { TranslationsKey } from "../../translations/types.js";
 
 import { canManageContent } from "../../common/access-control.js";
 import { getLivePreviewUrl } from "../../common/live-preview.js";
+import { pathnameBelongsToRootPath } from "../../common/pathname.js";
 import { contentField } from "../../fields/content.js";
 import { descriptionField } from "../../fields/description.js";
 import { heroField } from "../../fields/hero.js";
 import { textField } from "../../fields/text.js";
 import { textareaField } from "../../fields/textarea.js";
 import { contentGroup } from "../../groups.js";
+import { getPageBrandId, syncBrandHomeLink } from "../brands/home-link.js";
 import {
   getLocalizedPathnameEndpoint,
   getPagesForPathname,
@@ -179,8 +181,8 @@ export function Pages({
             Field: "@fxmk/cms-plugin/client#PathnameField",
           },
           description: {
-            en: "The pathname is used to navigate to this page. It must be unique. The first path segment must be the brand's home link.",
-            es: "La ruta se utiliza para navegar a esta página. Debe ser única. El primer segmento de la ruta debe ser el enlace de inicio de la marca.",
+            en: "The pathname is used to navigate to this page. It must be unique and start with the brand's root path.",
+            es: "La ruta se utiliza para navegar a esta página. Debe ser única y comenzar con la ruta raíz de la marca.",
           },
           placeholder: "e.g. /experiences/lost-city",
           position: "sidebar",
@@ -261,28 +263,25 @@ export function Pages({
             depth: 2,
             select: {
               homeLink: true,
+              rootPath: true,
             },
           });
 
+          const brandRootPath =
+            typeof brand.rootPath === "string" ? brand.rootPath : undefined;
           const pageRelationship = brand.homeLink as
             | Record<string, unknown>
             | undefined;
-          if (pageRelationship?.doc) {
-            // Brand does not have a home link, so we can't validate the pathname.
-            // We can't make the brand home link required, because we need to create a brand when there is no page yet.
+          const legacyHomeLinkPathname = pageRelationship?.doc
+            ? ((pageRelationship.doc as Record<string, unknown>)
+                .pathname as string)
+            : undefined;
+          const rootPath = brandRootPath ?? legacyHomeLinkPathname;
 
-            const brandHomeLinkPathname = (
-              pageRelationship.doc as Record<string, unknown>
-            ).pathname as string;
-            const safePrefix = brandHomeLinkPathname.endsWith("/")
-              ? brandHomeLinkPathname
-              : brandHomeLinkPathname + "/";
-            if (
-              value !== brandHomeLinkPathname &&
-              !value.startsWith(safePrefix)
-            ) {
+          if (rootPath) {
+            if (!pathnameBelongsToRootPath(value, rootPath)) {
               return t("cmsPlugin:pages:pathname:pathnameMustStartWithPrefix", {
-                prefix: brandHomeLinkPathname,
+                prefix: rootPath,
               });
             }
           }
@@ -328,6 +327,28 @@ export function Pages({
         required: false,
       }),
     ],
+    hooks: {
+      afterChange: [
+        async ({ doc, operation, previousDoc, req }) => {
+          if (operation !== "create" && operation !== "update") {
+            return;
+          }
+
+          const brandId = getPageBrandId(doc as Record<string, unknown>);
+          const previousBrandId =
+            previousDoc &&
+            getPageBrandId(previousDoc as Record<string, unknown>);
+
+          if (brandId) {
+            await syncBrandHomeLink({ brandId, req });
+          }
+
+          if (previousBrandId && previousBrandId !== brandId) {
+            await syncBrandHomeLink({ brandId: previousBrandId, req });
+          }
+        },
+      ],
+    },
     labels: {
       plural: {
         en: "Pages",

--- a/libs/cms-plugin/src/collections/pages/config.ts
+++ b/libs/cms-plugin/src/collections/pages/config.ts
@@ -349,6 +349,15 @@ export function Pages({
           }
         },
       ],
+      afterDelete: [
+        async ({ doc, req }) => {
+          const brandId = getPageBrandId(doc as Record<string, unknown>);
+
+          if (brandId) {
+            await syncBrandHomeLink({ brandId, req });
+          }
+        },
+      ],
     },
     labels: {
       plural: {

--- a/libs/cms-plugin/src/collections/pages/config.ts
+++ b/libs/cms-plugin/src/collections/pages/config.ts
@@ -261,6 +261,7 @@ export function Pages({
             id: siblingData.brand as string,
             collection: "brands",
             depth: 2,
+            req,
             select: {
               homeLink: true,
               rootPath: true,

--- a/libs/cms-plugin/src/common/pathname.ts
+++ b/libs/cms-plugin/src/common/pathname.ts
@@ -1,0 +1,36 @@
+export type RootPathValidationError =
+  | "mustNotEndWithSlash"
+  | "mustStartWithSlash";
+
+export function normalizePathnameInput(pathname: string) {
+  return pathname.trim();
+}
+
+export function validateRootPathFormat(
+  rootPath: string,
+): RootPathValidationError | true {
+  const normalizedRootPath = normalizePathnameInput(rootPath);
+
+  if (!normalizedRootPath.startsWith("/")) {
+    return "mustStartWithSlash";
+  }
+
+  if (normalizedRootPath !== "/" && normalizedRootPath.endsWith("/")) {
+    return "mustNotEndWithSlash";
+  }
+
+  return true;
+}
+
+export function pathnameBelongsToRootPath(pathname: string, rootPath: string) {
+  const normalizedPathname = normalizePathnameInput(pathname);
+  const normalizedRootPath = normalizePathnameInput(rootPath);
+  const safePrefix = normalizedRootPath.endsWith("/")
+    ? normalizedRootPath
+    : normalizedRootPath + "/";
+
+  return (
+    normalizedPathname === normalizedRootPath ||
+    normalizedPathname.startsWith(safePrefix)
+  );
+}

--- a/libs/cms-plugin/src/translations/locales/en.ts
+++ b/libs/cms-plugin/src/translations/locales/en.ts
@@ -35,6 +35,11 @@ export const en = {
     },
     brands: {
       navLinkRowLabel: "Navigation Link {{ n }}",
+      rootPath: {
+        alreadyExists: "There is already a brand with this root path.",
+        mustNotEndWithSlash: "The root path must not end with '/'.",
+        mustStartWithSlash: "The root path must start with '/'.",
+      },
     },
     common: {
       id: "ID",

--- a/libs/cms-plugin/src/translations/locales/en.ts
+++ b/libs/cms-plugin/src/translations/locales/en.ts
@@ -39,6 +39,7 @@ export const en = {
         alreadyExists: "There is already a brand with this root path.",
         mustNotEndWithSlash: "The root path must not end with '/'.",
         mustStartWithSlash: "The root path must start with '/'.",
+        overlaps: "The root path overlaps with another brand's root path.",
       },
     },
     common: {

--- a/libs/cms-plugin/src/translations/locales/es.ts
+++ b/libs/cms-plugin/src/translations/locales/es.ts
@@ -37,6 +37,7 @@ export const es: TranslationsObject = {
         alreadyExists: "Ya existe una marca con esta ruta raíz.",
         mustNotEndWithSlash: "La ruta raíz no debe terminar con '/'.",
         mustStartWithSlash: "La ruta raíz debe comenzar con '/'.",
+        overlaps: "La ruta raíz se solapa con la ruta raíz de otra marca.",
       },
     },
     common: {

--- a/libs/cms-plugin/src/translations/locales/es.ts
+++ b/libs/cms-plugin/src/translations/locales/es.ts
@@ -33,6 +33,11 @@ export const es: TranslationsObject = {
     },
     brands: {
       navLinkRowLabel: "Enlace de navegación {{ n }}",
+      rootPath: {
+        alreadyExists: "Ya existe una marca con esta ruta raíz.",
+        mustNotEndWithSlash: "La ruta raíz no debe terminar con '/'.",
+        mustStartWithSlash: "La ruta raíz debe comenzar con '/'.",
+      },
     },
     common: {
       id: "ID",

--- a/libs/cms-plugin/tests/collections/brands/home-link.test.ts
+++ b/libs/cms-plugin/tests/collections/brands/home-link.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from "vitest";
+
+import { getRootPathsByLocale } from "../../../src/collections/brands/home-link.js";
+
+describe("brand home link helpers", () => {
+  it("collects root paths for all published locales", () => {
+    expect(
+      getRootPathsByLocale(
+        {
+          en: "/brand",
+          es: "/marca",
+        },
+        ["en", "es"],
+      ),
+    ).toEqual([
+      { localeId: "en", rootPath: "/brand" },
+      { localeId: "es", rootPath: "/marca" },
+    ]);
+  });
+
+  it("ignores unpublished and missing localized root paths", () => {
+    expect(
+      getRootPathsByLocale(
+        {
+          en: "/brand",
+          fr: "/marque",
+        },
+        ["en", "es"],
+      ),
+    ).toEqual([{ localeId: "en", rootPath: "/brand" }]);
+  });
+});

--- a/libs/cms-plugin/tests/collections/brands/root-path.test.ts
+++ b/libs/cms-plugin/tests/collections/brands/root-path.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from "vitest";
+
+import { rootPathsOverlap } from "../../../src/collections/brands/root-path.js";
+
+describe("brand root path helpers", () => {
+  it("detects equal root paths as overlapping", () => {
+    expect(rootPathsOverlap("/brand", "/brand")).toBe(true);
+  });
+
+  it("detects parent and child root paths as overlapping", () => {
+    expect(rootPathsOverlap("/brand", "/brand/sub")).toBe(true);
+    expect(rootPathsOverlap("/brand/sub", "/brand")).toBe(true);
+  });
+
+  it("treats the site root as overlapping every child path", () => {
+    expect(rootPathsOverlap("/", "/brand")).toBe(true);
+  });
+
+  it("does not treat sibling path prefixes as overlapping", () => {
+    expect(rootPathsOverlap("/brand", "/brandish")).toBe(false);
+  });
+});

--- a/libs/cms-plugin/tests/common/pathname.test.ts
+++ b/libs/cms-plugin/tests/common/pathname.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  normalizePathnameInput,
+  pathnameBelongsToRootPath,
+  validateRootPathFormat,
+} from "../../src/common/pathname.js";
+
+describe("pathname helpers", () => {
+  it("normalizes pathname input whitespace", () => {
+    expect(normalizePathnameInput("  /brand  ")).toBe("/brand");
+  });
+
+  it("validates root path format", () => {
+    expect(validateRootPathFormat("brand")).toBe("mustStartWithSlash");
+    expect(validateRootPathFormat("/brand/")).toBe("mustNotEndWithSlash");
+    expect(validateRootPathFormat("/brand")).toBe(true);
+  });
+
+  it("matches a page pathname equal to the brand root path", () => {
+    expect(pathnameBelongsToRootPath("/brand", "/brand")).toBe(true);
+  });
+
+  it("matches a page pathname below the brand root path", () => {
+    expect(pathnameBelongsToRootPath("/brand/about", "/brand")).toBe(true);
+  });
+
+  it("rejects sibling path prefixes", () => {
+    expect(pathnameBelongsToRootPath("/brandish", "/brand")).toBe(false);
+  });
+});


### PR DESCRIPTION
## Context
Adding a new brand in the CMS had a chicken-and-egg workflow: pages require an immutable brand selection, but brands previously depended on a home page link to define their URL prefix. Because the home link could not be edited later by content editors, creating a complete new brand was blocked.

## What Changed
- Added a localized `rootPath` field to brands and use it as the source of truth for the brand URL namespace.
- Updated page pathname validation to accept the brand root path itself or child paths below it, with a legacy fallback to `homeLink` for brands that do not yet have `rootPath`.
- Reject overlapping brand root namespaces such as `/brand` and `/brand/sub`, including `/` overlapping child paths.
- Kept `homeLink` in the API as a hidden, auto-managed compatibility field derived from the page whose localized pathname equals the brand root path.
- Synced `homeLink` after page create/update/delete and after brand root path changes, while preserving the global home link across locale-only misses.
- Guarded brand syncs against recursive updates when localized root paths are loaded as objects under `locale: "all"`.
- Documented `rootPath` as the preferred public API for brand routing and clarified that `homeLink` is derived compatibility data.
- Split brand root-path field construction and validation into a focused helper to keep the brand collection config smaller.
- Updated brand live preview to use `rootPath`, translations, generated Payload example types, and focused pathname/home-link helper tests.

## Risks and Mitigations
- Existing brands without `rootPath` need editors to fill the new required field before normal editing; page validation keeps a legacy `homeLink` fallback until then.
- `homeLink` remains available to API consumers for compatibility, but it should be treated as derived data going forward.
- Localized path validation depends on the active Payload request locale; this is covered by passing `req` into brand lookups during page validation and by querying all published locales for global `homeLink` sync.
- Nested brand namespaces are now rejected to avoid ambiguous page ownership.

## Verification
- `pnpm --filter cms-plugin test:int`
- `pnpm --filter cms-plugin lint` (passes with existing warnings)
- `pnpm --filter cms-plugin build`
- `pnpm --filter cms-example generate:types`
- `pnpm --filter cms-example build`
- `pnpm check` (passes with existing warnings)
- `pnpm build`