### PR TITLE
fix(ci): publish Chromatic Storybook without TurboSnap

### DIFF
--- a/.github/workflows/export.build.yml
+++ b/.github/workflows/export.build.yml
@@ -158,7 +158,6 @@ jobs:
         with:
           projectToken: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
           exitOnceUploaded: true
-          onlyChanged: true
           workingDir: apps/frontend
           storybookBaseDir: apps/frontend
         env:


### PR DESCRIPTION
## Summary
- remove `onlyChanged: true` from the exported Chromatic publish job
- keep `exitOnceUploaded: true` so Chromatic exits successfully after Storybook upload

## Why
Consuming projects no longer use Chromatic UI Tests/regression checks because they require a plan upgrade. `onlyChanged` enables TurboSnap, which belongs to the UI Tests path. For the current use case we only need Storybook publishing.

## Validation
- `pnpm exec prettier --check .github/workflows/export.build.yml`