### PR TITLE
feat(cms-plugin): configure media organization

### DIFF
--- a/libs/cms-plugin/README.md
+++ b/libs/cms-plugin/README.md
@@ -92,6 +92,19 @@ cmsPlugin({
 });
 ```
 
+```ts
+import { migrateMediaCategoriesToFolders } from "@fxmk/cms-plugin";
+
+await migrateMediaCategoriesToFolders({
+  payload,
+  req,
+});
+```
+
+By default the migration helper creates or reuses top-level folders. Pass
+`parentFolderID` if migrated category folders should live under a specific
+existing folder.
+
 ## Building the Plugin
 
 When you build a plugin, you are purely building a feature for your project and

--- a/libs/cms-plugin/README.md
+++ b/libs/cms-plugin/README.md
@@ -44,6 +44,54 @@ The initialization process goes in the following order:
 4. Sanitization cleans and validates data
 5. Final config gets initialized
 
+### Media organization
+
+The plugin organizes uploads with the legacy media category collection by
+default. Consumers can opt into Payload's native folders, or disable built-in
+media organization entirely:
+
+```ts
+cmsPlugin({
+  media: {
+    organization: "folders",
+  },
+  mediaS3Storage: {
+    accessKeyId: process.env.MEDIA_S3_ACCESS_KEY_ID || "",
+    bucket: process.env.MEDIA_S3_BUCKET || "",
+    region: process.env.MEDIA_S3_REGION || "",
+    secretAccessKey: process.env.MEDIA_S3_SECRET_ACCESS_KEY || "",
+  },
+});
+```
+
+Available organization modes:
+
+- `"categories"` keeps the existing `mediaCategory` collection and `category`
+  relationship field. This is the default.
+- `"folders"` enables Payload folders on the `media` collection and the
+  browse-by-folder admin view.
+- `"none"` leaves media without plugin-provided categories or folders.
+
+For existing projects migrating from categories to folders, deploy once with
+`retainLegacyCategories: true`, run a Payload migration that calls
+`migrateMediaCategoriesToFolders`, verify the media folder assignments, and then
+remove `retainLegacyCategories`.
+
+```ts
+cmsPlugin({
+  media: {
+    organization: "folders",
+    retainLegacyCategories: true,
+  },
+  mediaS3Storage: {
+    accessKeyId: process.env.MEDIA_S3_ACCESS_KEY_ID || "",
+    bucket: process.env.MEDIA_S3_BUCKET || "",
+    region: process.env.MEDIA_S3_REGION || "",
+    secretAccessKey: process.env.MEDIA_S3_SECRET_ACCESS_KEY || "",
+  },
+});
+```
+
 ## Building the Plugin
 
 When you build a plugin, you are purely building a feature for your project and

--- a/libs/cms-plugin/src/collections/media/config.ts
+++ b/libs/cms-plugin/src/collections/media/config.ts
@@ -7,6 +7,20 @@ import { translated } from "../../translations/translations.js";
 import { generateAltTextEndpoint } from "./generate-alt-text-endpoint.js";
 import { mediaUsagesField } from "./usages.js";
 
+function categoryField({ hidden }: { hidden: boolean }): Field {
+  return {
+    name: "category",
+    type: "relationship",
+    admin: {
+      description: translated("cmsPlugin:media:category:description"),
+      hidden,
+      position: "sidebar",
+    },
+    label: translated("cmsPlugin:media:category:label"),
+    relationTo: "mediaCategory",
+  };
+}
+
 export function Media({
   generateAltTextOptions,
   organization = "categories",
@@ -20,19 +34,7 @@ export function Media({
     organization === "categories" || retainLegacyCategories;
   const fields: Field[] = [
     ...(includeCategoryField
-      ? [
-          {
-            name: "category",
-            type: "relationship" as const,
-            admin: {
-              description: translated("cmsPlugin:media:category:description"),
-              hidden: organization !== "categories",
-              position: "sidebar" as const,
-            },
-            label: translated("cmsPlugin:media:category:label"),
-            relationTo: "mediaCategory",
-          },
-        ]
+      ? [categoryField({ hidden: organization !== "categories" })]
       : []),
 
     {

--- a/libs/cms-plugin/src/collections/media/config.ts
+++ b/libs/cms-plugin/src/collections/media/config.ts
@@ -1,4 +1,4 @@
-import type { CollectionConfig } from "payload";
+import type { CollectionConfig, Field } from "payload";
 
 import { canManageContent } from "../../common/access-control.js";
 import { textareaField } from "../../fields/textarea.js";
@@ -9,9 +9,69 @@ import { mediaUsagesField } from "./usages.js";
 
 export function Media({
   generateAltTextOptions,
+  organization = "categories",
+  retainLegacyCategories = false,
 }: {
   generateAltTextOptions?: { publicMediaBaseUrl: string };
+  organization?: "categories" | "folders" | "none";
+  retainLegacyCategories?: boolean;
 } = {}): CollectionConfig {
+  const includeCategoryField =
+    organization === "categories" || retainLegacyCategories;
+  const fields: Field[] = [
+    ...(includeCategoryField
+      ? [
+          {
+            name: "category",
+            type: "relationship" as const,
+            admin: {
+              description: translated("cmsPlugin:media:category:description"),
+              hidden: organization !== "categories",
+              position: "sidebar" as const,
+            },
+            label: translated("cmsPlugin:media:category:label"),
+            relationTo: "mediaCategory",
+          },
+        ]
+      : []),
+
+    {
+      name: "comment",
+      type: "textarea",
+      admin: {
+        description: translated("cmsPlugin:media:comment:description"),
+        position: "sidebar",
+      },
+      label: translated("cmsPlugin:media:comment:label"),
+    },
+
+    {
+      type: "tabs",
+      tabs: [
+        {
+          fields: [
+            textareaField({
+              name: "alt",
+              admin: {
+                components: {
+                  afterInput: ["@fxmk/cms-plugin/client#GenerateAltTextButton"],
+                },
+                description: translated("cmsPlugin:media:alt:description"),
+              },
+              label: translated("cmsPlugin:media:alt:label"),
+              required: false,
+            }),
+          ],
+          label: translated("cmsPlugin:media:alt:label"),
+        },
+        {
+          fields: [mediaUsagesField()],
+          label: translated("cmsPlugin:common:usages:label"),
+        },
+      ],
+    },
+  ];
+
   return {
     slug: "media",
     access: {
@@ -20,7 +80,10 @@ export function Media({
       update: canManageContent,
     },
     admin: {
-      defaultColumns: ["filename", "category", "comment", "updatedAt"],
+      defaultColumns:
+        organization === "categories"
+          ? ["filename", "category", "comment", "updatedAt"]
+          : ["filename", "comment", "updatedAt"],
       group: contentGroup,
       listSearchableFields: ["id", "filename", "comment", "alt"],
     },
@@ -35,56 +98,8 @@ export function Media({
     endpoints: generateAltTextOptions
       ? [generateAltTextEndpoint(generateAltTextOptions)]
       : [],
-    fields: [
-      {
-        name: "category",
-        type: "relationship",
-        admin: {
-          description: translated("cmsPlugin:media:category:description"),
-          position: "sidebar",
-        },
-        label: translated("cmsPlugin:media:category:label"),
-        relationTo: "mediaCategory",
-      },
-
-      {
-        name: "comment",
-        type: "textarea",
-        admin: {
-          description: translated("cmsPlugin:media:comment:description"),
-          position: "sidebar",
-        },
-        label: translated("cmsPlugin:media:comment:label"),
-      },
-
-      {
-        type: "tabs",
-        tabs: [
-          {
-            fields: [
-              textareaField({
-                name: "alt",
-                admin: {
-                  components: {
-                    afterInput: [
-                      "@fxmk/cms-plugin/client#GenerateAltTextButton",
-                    ],
-                  },
-                  description: translated("cmsPlugin:media:alt:description"),
-                },
-                label: translated("cmsPlugin:media:alt:label"),
-                required: false,
-              }),
-            ],
-            label: translated("cmsPlugin:media:alt:label"),
-          },
-          {
-            fields: [mediaUsagesField()],
-            label: translated("cmsPlugin:common:usages:label"),
-          },
-        ],
-      },
-    ],
+    fields,
+    folders: organization === "folders" ? true : undefined,
     labels: {
       plural: translated("cmsPlugin:media:labels:plural"),
       singular: translated("cmsPlugin:media:labels:singular"),

--- a/libs/cms-plugin/src/collections/media/migrate-categories-to-folders.ts
+++ b/libs/cms-plugin/src/collections/media/migrate-categories-to-folders.ts
@@ -13,6 +13,7 @@ type MediaWithLegacyCategory = {
 };
 
 type FolderDocument = {
+  folder?: FolderDocument | ID | null;
   folderType?: string[];
   id: ID;
   name: string;
@@ -25,6 +26,7 @@ export type MigrateMediaCategoriesToFoldersOptions = {
   folderFieldName?: string;
   folderType?: false | string;
   mediaCollectionSlug?: string;
+  parentFolderID?: ID;
   payload: Payload;
   req?: PayloadRequest;
 };
@@ -57,6 +59,13 @@ function relationshipID(value: unknown): ID | undefined {
   return undefined;
 }
 
+function folderMatchesParent(
+  folder: FolderDocument,
+  parentFolderID: ID | null,
+) {
+  return (relationshipID(folder.folder) ?? null) === parentFolderID;
+}
+
 function folderNameForCategory(
   category: LegacyMediaCategory,
   categoryNameCounts: Map<string, number>,
@@ -74,6 +83,7 @@ export async function migrateMediaCategoriesToFolders({
   folderFieldName = "folder",
   folderType = "media",
   mediaCollectionSlug = "media",
+  parentFolderID,
   payload,
   req,
 }: MigrateMediaCategoriesToFoldersOptions): Promise<MigrateMediaCategoriesToFoldersResult> {
@@ -115,6 +125,7 @@ export async function migrateMediaCategoriesToFolders({
     result.categoriesProcessed += 1;
 
     const folderName = folderNameForCategory(category, categoryNameCounts);
+    const parentFolder = parentFolderID ?? null;
     const existingFolders = (
       await find({
         collection: folderCollectionSlug,
@@ -124,16 +135,25 @@ export async function migrateMediaCategoriesToFolders({
           name: {
             equals: folderName,
           },
+          [folderFieldName]:
+            parentFolder === null
+              ? {
+                  exists: false,
+                }
+              : {
+                  equals: parentFolder,
+                },
         },
         ...requestOptions,
       })
     ).docs as FolderDocument[];
     const folder = existingFolders.find(
       (existingFolder) =>
-        !folderType ||
-        !existingFolder.folderType ||
-        existingFolder.folderType.length === 0 ||
-        existingFolder.folderType.includes(folderType),
+        folderMatchesParent(existingFolder, parentFolder) &&
+        (!folderType ||
+          !existingFolder.folderType ||
+          existingFolder.folderType.length === 0 ||
+          existingFolder.folderType.includes(folderType)),
     );
 
     const folderID =
@@ -145,6 +165,9 @@ export async function migrateMediaCategoriesToFolders({
               collection: folderCollectionSlug,
               data: {
                 name: folderName,
+                ...(parentFolder === null
+                  ? {}
+                  : { [folderFieldName]: parentFolder }),
                 ...(folderType ? { folderType: [folderType] } : {}),
               },
               ...requestOptions,

--- a/libs/cms-plugin/src/collections/media/migrate-categories-to-folders.ts
+++ b/libs/cms-plugin/src/collections/media/migrate-categories-to-folders.ts
@@ -1,0 +1,202 @@
+import type { Payload, PayloadRequest } from "payload";
+
+type ID = number | string;
+
+type LegacyMediaCategory = {
+  id: ID;
+  name: string;
+};
+
+type MediaWithLegacyCategory = {
+  [key: string]: unknown;
+  id: ID;
+};
+
+type FolderDocument = {
+  folderType?: string[];
+  id: ID;
+  name: string;
+};
+
+export type MigrateMediaCategoriesToFoldersOptions = {
+  categoryCollectionSlug?: string;
+  dryRun?: boolean;
+  folderCollectionSlug?: string;
+  folderFieldName?: string;
+  folderType?: false | string;
+  mediaCollectionSlug?: string;
+  payload: Payload;
+  req?: PayloadRequest;
+};
+
+export type MigrateMediaCategoriesToFoldersResult = {
+  categoriesProcessed: number;
+  dryRun: boolean;
+  foldersCreated: number;
+  foldersReused: number;
+  mediaSkipped: number;
+  mediaUpdated: number;
+};
+
+type FindResult<T> = {
+  docs: T[];
+};
+
+function relationshipID(value: unknown): ID | undefined {
+  if (typeof value === "number" || typeof value === "string") {
+    return value;
+  }
+
+  if (value && typeof value === "object" && "id" in value) {
+    const id = value.id;
+    if (typeof id === "number" || typeof id === "string") {
+      return id;
+    }
+  }
+
+  return undefined;
+}
+
+function folderNameForCategory(
+  category: LegacyMediaCategory,
+  categoryNameCounts: Map<string, number>,
+) {
+  const categoryNameCount = categoryNameCounts.get(category.name) ?? 0;
+  return categoryNameCount > 1
+    ? `${category.name} (${category.id})`
+    : category.name;
+}
+
+export async function migrateMediaCategoriesToFolders({
+  categoryCollectionSlug = "mediaCategory",
+  dryRun = false,
+  folderCollectionSlug = "payload-folders",
+  folderFieldName = "folder",
+  folderType = "media",
+  mediaCollectionSlug = "media",
+  payload,
+  req,
+}: MigrateMediaCategoriesToFoldersOptions): Promise<MigrateMediaCategoriesToFoldersResult> {
+  const result: MigrateMediaCategoriesToFoldersResult = {
+    categoriesProcessed: 0,
+    dryRun,
+    foldersCreated: 0,
+    foldersReused: 0,
+    mediaSkipped: 0,
+    mediaUpdated: 0,
+  };
+
+  const requestOptions = req ? { req } : {};
+  const find = payload.find.bind(payload) as unknown as (
+    options: Record<string, unknown>,
+  ) => Promise<FindResult<unknown>>;
+  const create = payload.create.bind(payload) as unknown as (
+    options: Record<string, unknown>,
+  ) => Promise<unknown>;
+  const update = payload.update.bind(payload) as unknown as (
+    options: Record<string, unknown>,
+  ) => Promise<unknown>;
+
+  const categories = (
+    await find({
+      collection: categoryCollectionSlug,
+      depth: 0,
+      pagination: false,
+      ...requestOptions,
+    })
+  ).docs as LegacyMediaCategory[];
+
+  const categoryNameCounts = categories.reduce((counts, category) => {
+    counts.set(category.name, (counts.get(category.name) ?? 0) + 1);
+    return counts;
+  }, new Map<string, number>());
+
+  for (const category of categories) {
+    result.categoriesProcessed += 1;
+
+    const folderName = folderNameForCategory(category, categoryNameCounts);
+    const existingFolders = (
+      await find({
+        collection: folderCollectionSlug,
+        depth: 0,
+        limit: 100,
+        where: {
+          name: {
+            equals: folderName,
+          },
+        },
+        ...requestOptions,
+      })
+    ).docs as FolderDocument[];
+    const folder = existingFolders.find(
+      (existingFolder) =>
+        !folderType ||
+        !existingFolder.folderType ||
+        existingFolder.folderType.length === 0 ||
+        existingFolder.folderType.includes(folderType),
+    );
+
+    const folderID =
+      folder?.id ??
+      (dryRun
+        ? `dry-run:${category.id}`
+        : relationshipID(
+            await create({
+              collection: folderCollectionSlug,
+              data: {
+                name: folderName,
+                ...(folderType ? { folderType: [folderType] } : {}),
+              },
+              ...requestOptions,
+            }),
+          ));
+
+    if (!folderID) {
+      throw new Error(
+        `Failed to create folder for category "${category.name}"`,
+      );
+    }
+
+    if (folder) {
+      result.foldersReused += 1;
+    } else {
+      result.foldersCreated += 1;
+    }
+
+    const media = (
+      await find({
+        collection: mediaCollectionSlug,
+        depth: 0,
+        pagination: false,
+        where: {
+          category: {
+            equals: category.id,
+          },
+        },
+        ...requestOptions,
+      })
+    ).docs as MediaWithLegacyCategory[];
+
+    for (const mediaItem of media) {
+      if (relationshipID(mediaItem[folderFieldName])) {
+        result.mediaSkipped += 1;
+        continue;
+      }
+
+      result.mediaUpdated += 1;
+
+      if (!dryRun) {
+        await update({
+          id: mediaItem.id,
+          collection: mediaCollectionSlug,
+          data: {
+            [folderFieldName]: folderID,
+          },
+          ...requestOptions,
+        });
+      }
+    }
+  }
+
+  return result;
+}

--- a/libs/cms-plugin/src/collections/media/migrate-categories-to-folders.ts
+++ b/libs/cms-plugin/src/collections/media/migrate-categories-to-folders.ts
@@ -44,6 +44,18 @@ type FindResult<T> = {
   docs: T[];
 };
 
+type PayloadCreate = (options: Record<string, unknown>) => Promise<unknown>;
+
+type PayloadFind = (
+  options: Record<string, unknown>,
+) => Promise<FindResult<unknown>>;
+
+type PayloadUpdate = (options: Record<string, unknown>) => Promise<unknown>;
+
+type RequestOptions = {
+  req?: PayloadRequest;
+};
+
 function relationshipID(value: unknown): ID | undefined {
   if (typeof value === "number" || typeof value === "string") {
     return value;
@@ -76,6 +88,142 @@ function folderNameForCategory(
     : category.name;
 }
 
+async function createFolder({
+  create,
+  folderCollectionSlug,
+  folderFieldName,
+  folderName,
+  folderType,
+  parentFolder,
+  requestOptions,
+}: {
+  create: PayloadCreate;
+  folderCollectionSlug: string;
+  folderFieldName: string;
+  folderName: string;
+  folderType: false | string;
+  parentFolder: ID | null;
+  requestOptions: RequestOptions;
+}) {
+  return relationshipID(
+    await create({
+      collection: folderCollectionSlug,
+      data: {
+        name: folderName,
+        ...(parentFolder === null ? {} : { [folderFieldName]: parentFolder }),
+        ...(folderType ? { folderType: [folderType] } : {}),
+      },
+      ...requestOptions,
+    }),
+  );
+}
+
+async function findCategories({
+  categoryCollectionSlug,
+  find,
+  requestOptions,
+}: {
+  categoryCollectionSlug: string;
+  find: PayloadFind;
+  requestOptions: RequestOptions;
+}) {
+  return (
+    await find({
+      collection: categoryCollectionSlug,
+      depth: 0,
+      pagination: false,
+      ...requestOptions,
+    })
+  ).docs as LegacyMediaCategory[];
+}
+
+async function findMediaForCategory({
+  categoryID,
+  find,
+  mediaCollectionSlug,
+  requestOptions,
+}: {
+  categoryID: ID;
+  find: PayloadFind;
+  mediaCollectionSlug: string;
+  requestOptions: RequestOptions;
+}) {
+  return (
+    await find({
+      collection: mediaCollectionSlug,
+      depth: 0,
+      pagination: false,
+      where: {
+        category: {
+          equals: categoryID,
+        },
+      },
+      ...requestOptions,
+    })
+  ).docs as MediaWithLegacyCategory[];
+}
+
+async function findReusableFolder({
+  find,
+  folderCollectionSlug,
+  folderFieldName,
+  folderName,
+  folderType,
+  parentFolder,
+  requestOptions,
+}: {
+  find: PayloadFind;
+  folderCollectionSlug: string;
+  folderFieldName: string;
+  folderName: string;
+  folderType: false | string;
+  parentFolder: ID | null;
+  requestOptions: RequestOptions;
+}) {
+  const existingFolders = (
+    await find({
+      collection: folderCollectionSlug,
+      depth: 0,
+      limit: 100,
+      where: {
+        name: {
+          equals: folderName,
+        },
+        ...(parentFolder === null
+          ? {
+              or: [
+                {
+                  [folderFieldName]: {
+                    exists: false,
+                  },
+                },
+                {
+                  [folderFieldName]: {
+                    equals: null,
+                  },
+                },
+              ],
+            }
+          : {
+              [folderFieldName]: {
+                equals: parentFolder,
+              },
+            }),
+      },
+      ...requestOptions,
+    })
+  ).docs as FolderDocument[];
+
+  return existingFolders.find(
+    (existingFolder) =>
+      folderMatchesParent(existingFolder, parentFolder) &&
+      (!folderType ||
+        !existingFolder.folderType ||
+        existingFolder.folderType.length === 0 ||
+        existingFolder.folderType.includes(folderType)),
+  );
+}
+
 export async function migrateMediaCategoriesToFolders({
   categoryCollectionSlug = "mediaCategory",
   dryRun = false,
@@ -97,24 +245,15 @@ export async function migrateMediaCategoriesToFolders({
   };
 
   const requestOptions = req ? { req } : {};
-  const find = payload.find.bind(payload) as unknown as (
-    options: Record<string, unknown>,
-  ) => Promise<FindResult<unknown>>;
-  const create = payload.create.bind(payload) as unknown as (
-    options: Record<string, unknown>,
-  ) => Promise<unknown>;
-  const update = payload.update.bind(payload) as unknown as (
-    options: Record<string, unknown>,
-  ) => Promise<unknown>;
+  const find = payload.find.bind(payload) as unknown as PayloadFind;
+  const create = payload.create.bind(payload) as unknown as PayloadCreate;
+  const update = payload.update.bind(payload) as unknown as PayloadUpdate;
 
-  const categories = (
-    await find({
-      collection: categoryCollectionSlug,
-      depth: 0,
-      pagination: false,
-      ...requestOptions,
-    })
-  ).docs as LegacyMediaCategory[];
+  const categories = await findCategories({
+    categoryCollectionSlug,
+    find,
+    requestOptions,
+  });
 
   const categoryNameCounts = categories.reduce((counts, category) => {
     counts.set(category.name, (counts.get(category.name) ?? 0) + 1);
@@ -126,53 +265,29 @@ export async function migrateMediaCategoriesToFolders({
 
     const folderName = folderNameForCategory(category, categoryNameCounts);
     const parentFolder = parentFolderID ?? null;
-    const existingFolders = (
-      await find({
-        collection: folderCollectionSlug,
-        depth: 0,
-        limit: 100,
-        where: {
-          name: {
-            equals: folderName,
-          },
-          [folderFieldName]:
-            parentFolder === null
-              ? {
-                  exists: false,
-                }
-              : {
-                  equals: parentFolder,
-                },
-        },
-        ...requestOptions,
-      })
-    ).docs as FolderDocument[];
-    const folder = existingFolders.find(
-      (existingFolder) =>
-        folderMatchesParent(existingFolder, parentFolder) &&
-        (!folderType ||
-          !existingFolder.folderType ||
-          existingFolder.folderType.length === 0 ||
-          existingFolder.folderType.includes(folderType)),
-    );
+    const folder = await findReusableFolder({
+      find,
+      folderCollectionSlug,
+      folderFieldName,
+      folderName,
+      folderType,
+      parentFolder,
+      requestOptions,
+    });
 
     const folderID =
       folder?.id ??
       (dryRun
         ? `dry-run:${category.id}`
-        : relationshipID(
-            await create({
-              collection: folderCollectionSlug,
-              data: {
-                name: folderName,
-                ...(parentFolder === null
-                  ? {}
-                  : { [folderFieldName]: parentFolder }),
-                ...(folderType ? { folderType: [folderType] } : {}),
-              },
-              ...requestOptions,
-            }),
-          ));
+        : await createFolder({
+            create,
+            folderCollectionSlug,
+            folderFieldName,
+            folderName,
+            folderType,
+            parentFolder,
+            requestOptions,
+          }));
 
     if (!folderID) {
       throw new Error(
@@ -186,19 +301,12 @@ export async function migrateMediaCategoriesToFolders({
       result.foldersCreated += 1;
     }
 
-    const media = (
-      await find({
-        collection: mediaCollectionSlug,
-        depth: 0,
-        pagination: false,
-        where: {
-          category: {
-            equals: category.id,
-          },
-        },
-        ...requestOptions,
-      })
-    ).docs as MediaWithLegacyCategory[];
+    const media = await findMediaForCategory({
+      categoryID: category.id,
+      find,
+      mediaCollectionSlug,
+      requestOptions,
+    });
 
     for (const mediaItem of media) {
       if (relationshipID(mediaItem[folderFieldName])) {

--- a/libs/cms-plugin/src/index.ts
+++ b/libs/cms-plugin/src/index.ts
@@ -21,9 +21,26 @@ import { Common } from "./globals/common/config.js";
 import { Settings } from "./globals/settings/config.js";
 import { translations } from "./translations/translations.js";
 
+export * from "./collections/media/migrate-categories-to-folders.js";
 export * from "./common/index.js";
 export * from "./fields/index.js";
 export * from "./groups.js";
+
+export type CmsPluginMediaOrganization = "categories" | "folders" | "none";
+
+export type CmsPluginMediaFoldersOptions = {
+  browseByFolder?: boolean;
+  collectionSpecific?: boolean;
+  debug?: boolean;
+  fieldName?: string;
+  slug?: string;
+};
+
+export type CmsPluginMediaOptions = {
+  folders?: CmsPluginMediaFoldersOptions;
+  organization?: CmsPluginMediaOrganization;
+  retainLegacyCategories?: boolean;
+};
 
 export type CmsPluginOptions = {
   additionalContentBlocks?: Block[];
@@ -32,6 +49,7 @@ export type CmsPluginOptions = {
   deeplApiKey?: string;
   e2eTestsApiKey?: string;
   livePreviewBaseUrl?: string;
+  media?: CmsPluginMediaOptions;
   mediaS3Storage: {
     accessKeyId: string;
     bucket: string;
@@ -51,6 +69,7 @@ export const cmsPlugin =
     deeplApiKey,
     e2eTestsApiKey,
     livePreviewBaseUrl,
+    media,
     mediaS3Storage,
     openaiApiKey,
     publicMediaBaseUrl,
@@ -69,14 +88,36 @@ export const cmsPlugin =
       initializeOpenAI({ apiKey: openaiApiKey });
     }
 
+    const mediaOrganization = media?.organization ?? "categories";
+    const retainLegacyCategories =
+      mediaOrganization === "folders" && media?.retainLegacyCategories === true;
+
+    if (mediaOrganization === "folders") {
+      const currentFolders =
+        config.folders === false ? undefined : config.folders;
+
+      config.folders = {
+        ...currentFolders,
+        ...media?.folders,
+        browseByFolder:
+          media?.folders?.browseByFolder ??
+          currentFolders?.browseByFolder ??
+          true,
+      };
+    }
+
     config.collections.push(
       Media({
         generateAltTextOptions: publicMediaBaseUrl
           ? { publicMediaBaseUrl }
           : undefined,
+        organization: mediaOrganization,
+        retainLegacyCategories,
       }),
     );
-    config.collections.push(MediaCategories);
+    if (mediaOrganization === "categories" || retainLegacyCategories) {
+      config.collections.push(MediaCategories);
+    }
     config.collections.push(Users);
     config.collections.push(ApiKeys);
     config.collections.push(LocaleConfigs);

--- a/libs/cms-plugin/src/index.ts
+++ b/libs/cms-plugin/src/index.ts
@@ -1,4 +1,4 @@
-import type { Block, Config, Field, Plugin } from "payload";
+import type { Block, CollectionConfig, Config, Field, Plugin } from "payload";
 
 import { s3Storage } from "@payloadcms/storage-s3";
 
@@ -28,8 +28,15 @@ export * from "./groups.js";
 
 export type CmsPluginMediaOrganization = "categories" | "folders" | "none";
 
+type CmsPluginFolderCollection = Omit<CollectionConfig, "trash">;
+
 export type CmsPluginMediaFoldersOptions = {
   browseByFolder?: boolean;
+  collectionOverrides?: (({
+    collection,
+  }: {
+    collection: CmsPluginFolderCollection;
+  }) => CmsPluginFolderCollection | Promise<CmsPluginFolderCollection>)[];
   collectionSpecific?: boolean;
   debug?: boolean;
   fieldName?: string;

--- a/libs/cms-plugin/tests/media-organization.test.ts
+++ b/libs/cms-plugin/tests/media-organization.test.ts
@@ -84,6 +84,24 @@ describe("media organization config", () => {
       transitionalConfig.collections?.map((collection) => collection.slug),
     ).toContain("mediaCategory");
   });
+
+  it("passes folder collection overrides through to Payload folders config", () => {
+    const collectionOverride = vi.fn(({ collection }) => collection);
+    const config = cmsPlugin({
+      media: {
+        folders: {
+          collectionOverrides: [collectionOverride],
+        },
+        organization: "folders",
+      },
+      mediaS3Storage: mediaS3Storage(),
+    })({});
+
+    expect(config.folders).toMatchObject({
+      browseByFolder: true,
+      collectionOverrides: [collectionOverride],
+    });
+  });
 });
 
 describe("migrateMediaCategoriesToFolders", () => {

--- a/libs/cms-plugin/tests/media-organization.test.ts
+++ b/libs/cms-plugin/tests/media-organization.test.ts
@@ -186,4 +186,90 @@ describe("migrateMediaCategoriesToFolders", () => {
     expect(payload.create).not.toHaveBeenCalled();
     expect(payload.update).not.toHaveBeenCalled();
   });
+
+  it("does not reuse nested folders when migrating to top-level folders", async () => {
+    const payload = {
+      create: vi.fn(async () => ({ id: "top-level-folder" })),
+      find: vi.fn(async (options) => {
+        if (options.collection === "mediaCategory") {
+          return { docs: [{ id: "category-1", name: "Rooms" }] };
+        }
+
+        if (options.collection === "payload-folders") {
+          return {
+            docs: [
+              {
+                folder: "parent-folder",
+                folderType: ["media"],
+                id: "nested-folder",
+                name: "Rooms",
+              },
+            ],
+          };
+        }
+
+        return { docs: [{ id: "media-1" }] };
+      }),
+      update: vi.fn(async () => ({})),
+    } as unknown as Payload;
+
+    const result = await migrateMediaCategoriesToFolders({ payload });
+
+    expect(result).toMatchObject({
+      foldersCreated: 1,
+      foldersReused: 0,
+      mediaUpdated: 1,
+    });
+    expect(payload.create).toHaveBeenCalledWith({
+      collection: "payload-folders",
+      data: {
+        folderType: ["media"],
+        name: "Rooms",
+      },
+    });
+    expect(payload.update).toHaveBeenCalledWith({
+      collection: "media",
+      data: { folder: "top-level-folder" },
+      id: "media-1",
+    });
+  });
+
+  it("can reuse folders under a caller-specified parent", async () => {
+    const payload = {
+      create: vi.fn(),
+      find: vi.fn(async (options) => {
+        if (options.collection === "mediaCategory") {
+          return { docs: [{ id: "category-1", name: "Rooms" }] };
+        }
+
+        if (options.collection === "payload-folders") {
+          return {
+            docs: [
+              {
+                folder: "category-parent",
+                folderType: ["media"],
+                id: "nested-folder",
+                name: "Rooms",
+              },
+            ],
+          };
+        }
+
+        return { docs: [{ id: "media-1" }] };
+      }),
+      update: vi.fn(async () => ({})),
+    } as unknown as Payload;
+
+    await migrateMediaCategoriesToFolders({
+      parentFolderID: "category-parent",
+      payload,
+    });
+
+    expect(payload.create).not.toHaveBeenCalled();
+    expect(payload.update).toHaveBeenCalledWith({
+      collection: "media",
+      data: { folder: "nested-folder" },
+      id: "media-1",
+    });
+  });
 });

--- a/libs/cms-plugin/tests/media-organization.test.ts
+++ b/libs/cms-plugin/tests/media-organization.test.ts
@@ -1,0 +1,171 @@
+import type { Config, Payload } from "payload";
+import { describe, expect, it, vi } from "vitest";
+
+import { Media } from "../src/collections/media/config.js";
+import { migrateMediaCategoriesToFolders } from "../src/collections/media/migrate-categories-to-folders.js";
+import { cmsPlugin } from "../src/index.js";
+
+vi.mock("@payloadcms/storage-s3", () => ({
+  s3Storage: vi.fn(() => (config: Config) => config),
+}));
+
+function mediaS3Storage() {
+  return {
+    accessKeyId: "access-key-id",
+    bucket: "bucket",
+    region: "region",
+    secretAccessKey: "secret-access-key",
+  };
+}
+
+function fieldNames(config = Media()) {
+  return config.fields.flatMap((field) =>
+    "name" in field && typeof field.name === "string" ? [field.name] : [],
+  );
+}
+
+describe("media organization config", () => {
+  it("keeps legacy categories by default", () => {
+    const media = Media();
+
+    expect(fieldNames(media)).toContain("category");
+    expect(media.admin?.defaultColumns).toContain("category");
+    expect(media.folders).toBeUndefined();
+  });
+
+  it("enables Payload folders without categories", () => {
+    const media = Media({ organization: "folders" });
+
+    expect(fieldNames(media)).not.toContain("category");
+    expect(media.admin?.defaultColumns).not.toContain("category");
+    expect(media.folders).toBe(true);
+  });
+
+  it("can retain a hidden category field during folder migration", () => {
+    const media = Media({
+      organization: "folders",
+      retainLegacyCategories: true,
+    });
+    const categoryField = media.fields.find(
+      (field) => "name" in field && field.name === "category",
+    );
+
+    expect(categoryField).toMatchObject({
+      admin: { hidden: true },
+      relationTo: "mediaCategory",
+    });
+    expect(media.admin?.defaultColumns).not.toContain("category");
+    expect(media.folders).toBe(true);
+  });
+
+  it("registers media categories only when configured", () => {
+    const config = cmsPlugin({ mediaS3Storage: mediaS3Storage() })({});
+
+    expect(config.collections?.map((collection) => collection.slug)).toContain(
+      "mediaCategory",
+    );
+
+    const foldersConfig = cmsPlugin({
+      media: { organization: "folders" },
+      mediaS3Storage: mediaS3Storage(),
+    })({});
+
+    expect(
+      foldersConfig.collections?.map((collection) => collection.slug),
+    ).not.toContain("mediaCategory");
+    expect(foldersConfig.folders).toMatchObject({ browseByFolder: true });
+
+    const transitionalConfig = cmsPlugin({
+      media: { organization: "folders", retainLegacyCategories: true },
+      mediaS3Storage: mediaS3Storage(),
+    })({});
+
+    expect(
+      transitionalConfig.collections?.map((collection) => collection.slug),
+    ).toContain("mediaCategory");
+  });
+});
+
+describe("migrateMediaCategoriesToFolders", () => {
+  it("creates folders and assigns media that do not already have a folder", async () => {
+    const payload = {
+      create: vi.fn(async () => ({ id: "folder-1" })),
+      find: vi.fn(async (options) => {
+        if (options.collection === "mediaCategory") {
+          return { docs: [{ id: "category-1", name: "Rooms" }] };
+        }
+
+        if (options.collection === "payload-folders") {
+          return { docs: [] };
+        }
+
+        return {
+          docs: [
+            { id: "media-1" },
+            { folder: "existing-folder", id: "media-2" },
+          ],
+        };
+      }),
+      update: vi.fn(async () => ({})),
+    } as unknown as Payload;
+
+    const result = await migrateMediaCategoriesToFolders({ payload });
+
+    expect(result).toEqual({
+      categoriesProcessed: 1,
+      dryRun: false,
+      foldersCreated: 1,
+      foldersReused: 0,
+      mediaSkipped: 1,
+      mediaUpdated: 1,
+    });
+    expect(payload.create).toHaveBeenCalledWith({
+      collection: "payload-folders",
+      data: {
+        folderType: ["media"],
+        name: "Rooms",
+      },
+    });
+    expect(payload.update).toHaveBeenCalledWith({
+      collection: "media",
+      data: { folder: "folder-1" },
+      id: "media-1",
+    });
+  });
+
+  it("reuses existing folders and supports dry runs", async () => {
+    const payload = {
+      create: vi.fn(),
+      find: vi.fn(async (options) => {
+        if (options.collection === "mediaCategory") {
+          return { docs: [{ id: "category-1", name: "Rooms" }] };
+        }
+
+        if (options.collection === "payload-folders") {
+          return {
+            docs: [{ folderType: ["media"], id: "folder-1", name: "Rooms" }],
+          };
+        }
+
+        return { docs: [{ id: "media-1" }] };
+      }),
+      update: vi.fn(),
+    } as unknown as Payload;
+
+    const result = await migrateMediaCategoriesToFolders({
+      dryRun: true,
+      payload,
+    });
+
+    expect(result).toEqual({
+      categoriesProcessed: 1,
+      dryRun: true,
+      foldersCreated: 0,
+      foldersReused: 1,
+      mediaSkipped: 0,
+      mediaUpdated: 1,
+    });
+    expect(payload.create).not.toHaveBeenCalled();
+    expect(payload.update).not.toHaveBeenCalled();
+  });
+});

--- a/libs/cms-plugin/tests/media-organization.test.ts
+++ b/libs/cms-plugin/tests/media-organization.test.ts
@@ -187,6 +187,42 @@ describe("migrateMediaCategoriesToFolders", () => {
     expect(payload.update).not.toHaveBeenCalled();
   });
 
+  it("reuses top-level folders with an explicit null parent", async () => {
+    const payload = {
+      create: vi.fn(),
+      find: vi.fn(async (options) => {
+        if (options.collection === "mediaCategory") {
+          return { docs: [{ id: "category-1", name: "Rooms" }] };
+        }
+
+        if (options.collection === "payload-folders") {
+          return {
+            docs: [
+              {
+                folder: null,
+                folderType: ["media"],
+                id: "folder-1",
+                name: "Rooms",
+              },
+            ],
+          };
+        }
+
+        return { docs: [{ id: "media-1" }] };
+      }),
+      update: vi.fn(async () => ({})),
+    } as unknown as Payload;
+
+    await migrateMediaCategoriesToFolders({ payload });
+
+    expect(payload.create).not.toHaveBeenCalled();
+    expect(payload.update).toHaveBeenCalledWith({
+      collection: "media",
+      data: { folder: "folder-1" },
+      id: "media-1",
+    });
+  });
+
   it("does not reuse nested folders when migrating to top-level folders", async () => {
     const payload = {
       create: vi.fn(async () => ({ id: "top-level-folder" })),


### PR DESCRIPTION
## Summary

- add configurable media organization to `cmsPlugin` with `categories`, `folders`, and `none` modes
- enable Payload native folders for media when consumers opt in, while preserving legacy categories by default
- export `migrateMediaCategoriesToFolders` for transitional category-to-folder migrations
- document folder opt-in and migration usage

## Context

Payload now supports native folders for upload collections. This PR lets new consumers use that admin experience without forcing a breaking migration on existing projects that already use `mediaCategory`.

## Migration notes

- Existing projects keep `media.organization: "categories"` by default.
- Projects moving to folders can deploy with `organization: "folders"` and `retainLegacyCategories: true`, run `migrateMediaCategoriesToFolders`, verify assignments, then remove legacy categories.
- The migration helper reuses top-level folders by default and supports `parentFolderID` for intentionally nested category folders.
- `media.folders.collectionOverrides` is exposed for consumers that customize Payload's generated folder collection.

## Validation

- `pnpm --filter cms-plugin lint` (passes with existing warnings)
- `pnpm --filter cms-plugin test:int --run`
- `pnpm --filter cms-plugin build`
- `pnpm --filter cms-example build`
- `pnpm format:check`
- `pnpm check` (passes with existing warnings)

## Risks and mitigations

- Payload folders are still a newer Payload feature, so the PR keeps legacy categories as the default.
- Migration is explicit rather than automatic, and the helper avoids reusing unrelated nested folders with the same name.