### PR TITLE
feat(cms-example): add staging fly deployment

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -131,6 +131,59 @@ jobs:
         env:
           FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
 
+  cms-example-image-ready:
+    name: "cms-example: Image Ready"
+    runs-on: ubuntu-latest
+    if: github.event_name != 'pull_request' && github.ref == 'refs/heads/main'
+    needs:
+      - version
+      - cms-example-build-push
+    steps:
+      - name: Log in to Fly registry
+        uses: docker/login-action@v4
+        with:
+          registry: registry.fly.io
+          username: x
+          password: ${{ secrets.FLY_API_TOKEN }}
+      - name: Wait for Fly registry image
+        run: |
+          set -euo pipefail
+
+          IMAGE="registry.fly.io/${{ vars.FLY_STAGING_CMS_EXAMPLE_APP }}:v${{ needs.version.outputs.version_with_sha }}"
+          MAX_ATTEMPTS=24
+          SLEEP_SECONDS=15
+          LAST_ERROR=""
+
+          for attempt in $(seq 1 "$MAX_ATTEMPTS"); do
+            ERROR_FILE="$(mktemp)"
+            if timeout 20s docker manifest inspect "$IMAGE" > /dev/null 2>"$ERROR_FILE"; then
+              rm -f "$ERROR_FILE"
+              echo "Image is available: $IMAGE"
+              exit 0
+            fi
+
+            ERROR_TEXT="$(tr '\n' ' ' < "$ERROR_FILE" | sed -E 's/[[:space:]]+/ /g')"
+            rm -f "$ERROR_FILE"
+            LAST_ERROR="$ERROR_TEXT"
+
+            if printf '%s' "$ERROR_TEXT" | grep -Eiq '(unauthorized|authentication required|denied|forbidden|insufficient_scope|access denied)'; then
+              echo "Registry auth/permission error while checking image: $IMAGE"
+              echo "docker manifest inspect error: $ERROR_TEXT"
+              exit 1
+            fi
+
+            if [ "$attempt" -lt "$MAX_ATTEMPTS" ]; then
+              echo "[$attempt/$MAX_ATTEMPTS] Waiting for image: $IMAGE"
+              sleep "$SLEEP_SECONDS"
+            else
+              echo "Timed out waiting for image: $IMAGE"
+              if [ -n "$LAST_ERROR" ]; then
+                echo "Last docker manifest inspect error: $LAST_ERROR"
+              fi
+              exit 1
+            fi
+          done
+
   cms-example-deploy:
     name: "cms-example: Deploy"
     runs-on: ubuntu-latest
@@ -141,7 +194,7 @@ jobs:
       - cms-plugin-build
       - common-build
       - cms-example-build
-      - cms-example-build-push
+      - cms-example-image-ready
     environment:
       name: staging-cms-example
       url: ${{ vars.SERVER_URL }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,6 +14,7 @@ on:
 
 env:
   NODE_VERSION: 24
+  FLYCTL_VERSION: 0.4.52
 
 jobs:
   version:
@@ -89,6 +90,97 @@ jobs:
         run: pnpm --filter cms-example --filter cms-plugin install
       - name: Build
         run: pnpm --filter cms-example build
+
+  cms-example-build-push:
+    name: "cms-example: Build and Push"
+    runs-on: ubuntu-latest
+    if: github.event_name != 'pull_request' && github.ref == 'refs/heads/main'
+    needs: [version]
+    outputs:
+      image: ${{ steps.image-name.outputs.image }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+      - name: Set up flyctl
+        uses: superfly/flyctl-actions/setup-flyctl@v1
+        with:
+          version: ${{ env.FLYCTL_VERSION }}
+      - name: Setup
+        uses: ./.github/actions/setup
+      - name: Set version on cms-example
+        run: |
+          pnpm version ${{ needs.version.outputs.version }} --git-tag-version false
+        working-directory: examples/cms-example
+      - name: Get cms-example image name
+        id: image-name
+        run: |
+          IMAGE_NAME=${{ vars.FLY_STAGING_CMS_EXAMPLE_APP }}
+          IMAGE_TAG=v${{ needs.version.outputs.version_with_sha }}
+          echo "image_name=$IMAGE_NAME" >> "$GITHUB_OUTPUT"
+          echo "image_tag=$IMAGE_TAG" >> "$GITHUB_OUTPUT"
+          echo "image=registry.fly.io/$IMAGE_NAME:$IMAGE_TAG" >> "$GITHUB_OUTPUT"
+      - name: Build and push cms-example Docker image
+        run: |
+          flyctl deploy \
+            --app ${{ steps.image-name.outputs.image_name }} \
+            --config examples/cms-example/fly.build.toml \
+            --build-only \
+            --image-label ${{ steps.image-name.outputs.image_tag }} \
+            --label org.opencontainers.image.version=${{ steps.image-name.outputs.image_tag }} \
+            --push
+        env:
+          FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
+
+  cms-example-deploy:
+    name: "cms-example: Deploy"
+    runs-on: ubuntu-latest
+    if: github.event_name != 'pull_request' && github.ref == 'refs/heads/main'
+    needs:
+      - version
+      - quality
+      - cms-plugin-build
+      - common-build
+      - cms-example-build
+      - cms-example-build-push
+    environment:
+      name: staging-cms-example
+      url: ${{ vars.SERVER_URL }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+      - name: Set up flyctl
+        uses: superfly/flyctl-actions/setup-flyctl@v1
+        with:
+          version: ${{ env.FLYCTL_VERSION }}
+      - name: Prepare configuration file
+        run: |
+          envsubst \
+            < examples/cms-example/fly.template.toml \
+            > examples/cms-example/fly.generated.toml
+
+          echo "Generated configuration file:"
+          cat examples/cms-example/fly.generated.toml
+        env:
+          FLY_APP: ${{ vars.FLY_STAGING_CMS_EXAMPLE_APP }}
+          FLY_PRIMARY_REGION: ${{ vars.FLY_PRIMARY_REGION }}
+          FLY_MIN_MACHINES_RUNNING: ${{ vars.FLY_MIN_MACHINES_RUNNING }}
+          FLY_MEMORY: ${{ vars.FLY_MEMORY }}
+          FLY_CPU_KIND: ${{ vars.FLY_CPU_KIND }}
+          FLY_CPUS: ${{ vars.FLY_CPUS }}
+          MEDIA_S3_REGION: ${{ vars.MEDIA_S3_REGION }}
+          MEDIA_S3_BUCKET: ${{ vars.MEDIA_S3_BUCKET }}
+          PUBLIC_MEDIA_BASE_URL: ${{ vars.PUBLIC_MEDIA_BASE_URL }}
+          SERVER_URL: ${{ vars.SERVER_URL }}
+          LIVE_PREVIEW_BASE_URL:
+            ${{ vars.LIVE_PREVIEW_BASE_URL || vars.SERVER_URL }}
+      - name: Deploy cms-example
+        run: |
+          flyctl deploy \
+            --config examples/cms-example/fly.generated.toml \
+            --ha=false \
+            --image registry.fly.io/${{ vars.FLY_STAGING_CMS_EXAMPLE_APP }}:v${{ needs.version.outputs.version_with_sha }}
+        env:
+          FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
 
   create-release:
     name: Create release

--- a/examples/cms-example/.env.example
+++ b/examples/cms-example/.env.example
@@ -1,2 +1,9 @@
 DATABASE_URI=mongodb://127.0.0.1/your-database-name
 PAYLOAD_SECRET=YOUR_SECRET_HERE
+MEDIA_S3_BUCKET=your-bucket
+MEDIA_S3_REGION=your-region
+MEDIA_S3_ACCESS_KEY_ID=your-access-key-id
+MEDIA_S3_SECRET_ACCESS_KEY=your-secret-access-key
+PUBLIC_MEDIA_BASE_URL=https://example-cdn-or-bucket-url
+SERVER_URL=http://localhost:3000
+LIVE_PREVIEW_BASE_URL=http://localhost:3000

--- a/examples/cms-example/Dockerfile
+++ b/examples/cms-example/Dockerfile
@@ -1,71 +1,48 @@
-# To use this Dockerfile, you have to set `output: 'standalone'` in your next.config.mjs file.
 # From https://github.com/vercel/next.js/blob/canary/examples/with-docker/Dockerfile
 
 FROM node:24-alpine AS base
 
-# Install dependencies only when needed
-FROM base AS deps
-# Check https://github.com/nodejs/docker-node/tree/b4117f9333da4138b03a546ec926ef50a31506c3#nodealpine to understand why libc6-compat might be needed.
+# Install latest corepack to keep pnpm activation aligned with the lockfile.
+RUN npm install -g corepack@latest
+
+FROM base AS builder
 RUN apk add --no-cache libc6-compat
 WORKDIR /app
+ENV CI=true
 
-# Install dependencies based on the preferred package manager
-COPY package.json yarn.lock* package-lock.json* pnpm-lock.yaml* ./
-RUN \
-  if [ -f yarn.lock ]; then yarn --frozen-lockfile; \
-  elif [ -f package-lock.json ]; then npm ci; \
-  elif [ -f pnpm-lock.yaml ]; then corepack enable pnpm && pnpm i --frozen-lockfile; \
-  else echo "Lockfile not found." && exit 1; \
-  fi
+RUN corepack enable pnpm
 
+COPY --link package.json pnpm-lock.yaml pnpm-workspace.yaml .npmrc ./
+COPY --link examples/cms-example examples/cms-example
+COPY --link libs/cms-plugin libs/cms-plugin
+COPY --link libs/common libs/common
 
-# Rebuild the source code only when needed
-FROM base AS builder
-WORKDIR /app
-COPY --from=deps /app/node_modules ./node_modules
-COPY . .
+RUN pnpm --filter cms-example --filter cms-plugin --filter common install --frozen-lockfile
+RUN pnpm --filter common build
+RUN pnpm --filter cms-plugin build
+RUN pnpm --filter cms-example build
 
-# Next.js collects completely anonymous telemetry data about general usage.
-# Learn more here: https://nextjs.org/telemetry
-# Uncomment the following line in case you want to disable telemetry during the build.
-# ENV NEXT_TELEMETRY_DISABLED 1
-
-RUN \
-  if [ -f yarn.lock ]; then yarn run build; \
-  elif [ -f package-lock.json ]; then npm run build; \
-  elif [ -f pnpm-lock.yaml ]; then corepack enable pnpm && pnpm run build; \
-  else echo "Lockfile not found." && exit 1; \
-  fi
-
-# Production image, copy all the files and run next
 FROM base AS runner
 WORKDIR /app
 
-ENV NODE_ENV production
-# Uncomment the following line in case you want to disable telemetry during runtime.
-# ENV NEXT_TELEMETRY_DISABLED 1
+ENV NODE_ENV=production
 
 RUN addgroup --system --gid 1001 nodejs
 RUN adduser --system --uid 1001 nextjs
 
-# Remove this line if you do not have this folder
-COPY --from=builder /app/public ./public
+COPY --from=builder /app .
 
-# Set the correct permission for prerender cache
-RUN mkdir .next
-RUN chown nextjs:nodejs .next
-
-# Automatically leverage output traces to reduce image size
-# https://nextjs.org/docs/advanced-features/output-file-tracing
-COPY --from=builder --chown=nextjs:nodejs /app/.next/standalone ./
-COPY --from=builder --chown=nextjs:nodejs /app/.next/static ./.next/static
+RUN mkdir -p examples/cms-example/.next/standalone/examples/cms-example/.next
+RUN mv examples/cms-example/.next/static examples/cms-example/.next/standalone/examples/cms-example/.next/static
+RUN if [ -d examples/cms-example/public ]; then \
+      cp -r examples/cms-example/public examples/cms-example/.next/standalone/examples/cms-example/public; \
+    fi
+RUN chown -R nextjs:nodejs examples/cms-example/.next/standalone/examples/cms-example/.next
 
 USER nextjs
 
 EXPOSE 3000
 
-ENV PORT 3000
+ENV PORT=3000
 
-# server.js is created by next build from the standalone output
-# https://nextjs.org/docs/pages/api-reference/next-config-js/output
-CMD HOSTNAME="0.0.0.0" node server.js
+CMD HOSTNAME="0.0.0.0" node examples/cms-example/.next/standalone/examples/cms-example/server.js

--- a/examples/cms-example/Dockerfile.dockerignore
+++ b/examples/cms-example/Dockerfile.dockerignore
@@ -1,0 +1,24 @@
+# Ignore everything
+**
+
+# But include the necessary parts
+!package.json
+!pnpm-lock.yaml
+!pnpm-workspace.yaml
+!.npmrc
+!/examples/cms-example
+!/libs/cms-plugin
+!/libs/common
+
+# These should be ignored, though
+**/.cms-cache
+**/.next
+**/.react-router
+**/build
+**/dist
+**/node_modules
+**/tests
+**/.env*
+**/tsconfig.tsbuildinfo
+**/.vscode
+**/.DS_Store

--- a/examples/cms-example/README.md
+++ b/examples/cms-example/README.md
@@ -34,6 +34,54 @@ on-screen instructions to login and create your first admin user. Then check out
 [Production](#production) once you're ready to build and serve your app, and
 [Deployment](#deployment) when you're ready to go live.
 
+## Staging deployment
+
+The staging app is deployed to Fly.io from the root `Build` GitHub Actions
+workflow on every non-PR build on `main`. The Fly app is stateless: MongoDB is
+external, media is stored in S3-compatible storage, and no Fly volume is
+required.
+
+Create the Fly app once:
+
+```bash
+flyctl apps create fxmk-webplatform-cms-example-staging --org <fly-org>
+```
+
+Set Fly app secrets:
+
+```bash
+flyctl secrets set --app fxmk-webplatform-cms-example-staging \
+  DATABASE_URI='mongodb+srv://...' \
+  PAYLOAD_SECRET='<openssl rand -hex 32>' \
+  MEDIA_S3_ACCESS_KEY_ID='...' \
+  MEDIA_S3_SECRET_ACCESS_KEY='...'
+```
+
+Optional feature secrets:
+
+```bash
+flyctl secrets set --app fxmk-webplatform-cms-example-staging \
+  OPENAI_API_KEY='...' \
+  DEEPL_API_KEY='...'
+```
+
+GitHub Actions requires the `FLY_API_TOKEN` secret and these repository
+variables:
+
+```text
+FLY_ORG=<fly-org>
+FLY_STAGING_CMS_EXAMPLE_APP=fxmk-webplatform-cms-example-staging
+FLY_PRIMARY_REGION=fra
+FLY_MIN_MACHINES_RUNNING=1
+FLY_MEMORY=1024
+FLY_CPU_KIND=shared
+FLY_CPUS=1
+MEDIA_S3_BUCKET=<existing-staging-safe-bucket>
+MEDIA_S3_REGION=<bucket-region>
+PUBLIC_MEDIA_BASE_URL=<public bucket/CDN base URL>
+SERVER_URL=https://fxmk-webplatform-cms-example-staging.fly.dev
+```
+
 #### Docker (Optional)
 
 If you prefer to use Docker for local development instead of a local MongoDB

--- a/examples/cms-example/fly.build.toml
+++ b/examples/cms-example/fly.build.toml
@@ -1,0 +1,5 @@
+# Dummy Dockerfile for Fly-/Depot-based Docker build (`fly deploy --dockerfile … --build-only –`
+# does not seem to work reliably without specifying a config file)
+
+[build]
+  dockerfile = 'Dockerfile'

--- a/examples/cms-example/fly.build.toml
+++ b/examples/cms-example/fly.build.toml
@@ -2,4 +2,4 @@
 # does not seem to work reliably without specifying a config file)
 
 [build]
-  dockerfile = 'Dockerfile'
+  dockerfile = 'examples/cms-example/Dockerfile'

--- a/examples/cms-example/fly.template.toml
+++ b/examples/cms-example/fly.template.toml
@@ -1,0 +1,26 @@
+#
+# See https://fly.io/docs/reference/configuration/ for information about how to use this file.
+#
+
+app = '$FLY_APP'
+primary_region = '$FLY_PRIMARY_REGION'
+
+[http_service]
+  internal_port = 3000
+  force_https = true
+  auto_stop_machines = true
+  auto_start_machines = true
+  min_machines_running = $FLY_MIN_MACHINES_RUNNING
+  processes = ['app']
+
+[[vm]]
+  memory = $FLY_MEMORY
+  cpu_kind = '$FLY_CPU_KIND'
+  cpus = $FLY_CPUS
+
+[env]
+  MEDIA_S3_REGION = '$MEDIA_S3_REGION'
+  MEDIA_S3_BUCKET = '$MEDIA_S3_BUCKET'
+  PUBLIC_MEDIA_BASE_URL = '$PUBLIC_MEDIA_BASE_URL'
+  SERVER_URL = '$SERVER_URL'
+  LIVE_PREVIEW_BASE_URL = '$LIVE_PREVIEW_BASE_URL'

--- a/examples/cms-example/next.config.mjs
+++ b/examples/cms-example/next.config.mjs
@@ -1,8 +1,14 @@
 import { withPayload } from "@payloadcms/next/withPayload";
+import path from "path";
+import { fileURLToPath } from "url";
+
+const filename = fileURLToPath(import.meta.url);
+const dirname = path.dirname(filename);
 
 /** @type {import('next').NextConfig} */
 const nextConfig = {
-  // Your Next.js config here
+  output: "standalone",
+  outputFileTracingRoot: path.join(dirname, "../.."),
   serverExternalPackages: ["jsdom"],
   webpack: (webpackConfig, { isServer }) => {
     if (isServer) {

--- a/examples/cms-example/src/payload.config.ts
+++ b/examples/cms-example/src/payload.config.ts
@@ -9,6 +9,8 @@ import { RoomListBlock } from "./blocks/room-list/config";
 
 const filename = fileURLToPath(import.meta.url);
 const dirname = path.dirname(filename);
+const serverUrl = process.env.SERVER_URL;
+const livePreviewBaseUrl = process.env.LIVE_PREVIEW_BASE_URL || serverUrl;
 
 export default buildConfig({
   secret: process.env.PAYLOAD_SECRET || "",
@@ -27,13 +29,14 @@ export default buildConfig({
       deeplApiKey: process.env.DEEPL_API_KEY,
       openaiApiKey: process.env.OPENAI_API_KEY,
       publicMediaBaseUrl: process.env.PUBLIC_MEDIA_BASE_URL,
+      serverUrl,
       mediaS3Storage: {
         bucket: process.env.MEDIA_S3_BUCKET || "",
         accessKeyId: process.env.MEDIA_S3_ACCESS_KEY_ID || "",
         secretAccessKey: process.env.MEDIA_S3_SECRET_ACCESS_KEY || "",
         region: process.env.MEDIA_S3_REGION || "",
       },
-      livePreviewBaseUrl: "https://example.com",
+      livePreviewBaseUrl,
     }),
   ],
   i18n: {


### PR DESCRIPTION
## Summary
- add Fly deployment config for `examples/cms-example` staging
- make the cms-example Dockerfile monorepo-aware and enable Next standalone output
- wire main-branch CI to build, push, and deploy the staging Fly image
- document required Fly app setup, GitHub variables, and secrets

## Validation
- `pnpm --filter cms-example build`
- `pnpm --filter common build && pnpm --filter cms-plugin build && pnpm --filter cms-example build`
- `pnpm check`

## Notes
- `docker build -f examples/cms-example/Dockerfile .` could not be run locally because the Docker daemon is not running in this environment.