### PR TITLE
fix(cms-plugin): keep root path localized

### DIFF
--- a/libs/cms-plugin/src/collections/brands/config.ts
+++ b/libs/cms-plugin/src/collections/brands/config.ts
@@ -14,7 +14,7 @@ import { showField } from "../../fields/show.js";
 import { textField } from "../../fields/text.js";
 import { contentGroup } from "../../groups.js";
 import { syncBrandHomeLink } from "./home-link.js";
-import { rootPathField } from "./root-path.js";
+import { resolveRootPathForLocale, rootPathField } from "./root-path.js";
 import { brandUsagesField } from "./usages.js";
 
 type BrandsOptions = {
@@ -47,7 +47,7 @@ export function Brands({
             }) => {
               return getLivePreviewUrl(
                 livePreviewBaseUrl,
-                typeof data.rootPath === "string" ? data.rootPath : "/",
+                resolveRootPathForLocale(data.rootPath, locale.code) ?? "/",
                 `brands/${data.id as string}`,
                 locale.code,
               );

--- a/libs/cms-plugin/src/collections/brands/home-link.ts
+++ b/libs/cms-plugin/src/collections/brands/home-link.ts
@@ -1,6 +1,9 @@
 import type { PayloadRequest } from "payload";
 
-import { getPublishedLocaleIds } from "./root-path.js";
+import {
+  getPublishedLocaleIds,
+  resolveRootPathForLocale,
+} from "./root-path.js";
 
 function getRelationshipId(value: unknown) {
   if (typeof value === "string") {
@@ -68,6 +71,9 @@ export async function syncBrandHomeLink({
   });
 
   const homePage = homePages.docs[0];
+  const locale = req.payload.config.localization
+    ? req.payload.config.localization.defaultLocale
+    : req.locale;
 
   await req.payload.update({
     id: brandId,
@@ -80,25 +86,20 @@ export async function syncBrandHomeLink({
           }
         : {},
     },
+    locale,
     overrideAccess: true,
     req,
   });
 }
 
 export function getRootPathsByLocale(rootPath: unknown, localeIds: string[]) {
-  if (typeof rootPath === "string") {
-    return localeIds.map((localeId) => ({ localeId, rootPath }));
-  }
-
   if (!rootPath || typeof rootPath !== "object" || Array.isArray(rootPath)) {
     return [];
   }
 
   return localeIds.flatMap((localeId) => {
-    const localizedRootPath = (rootPath as Record<string, unknown>)[localeId];
+    const localizedRootPath = resolveRootPathForLocale(rootPath, localeId);
 
-    return typeof localizedRootPath === "string"
-      ? [{ localeId, rootPath: localizedRootPath }]
-      : [];
+    return localizedRootPath ? [{ localeId, rootPath: localizedRootPath }] : [];
   });
 }

--- a/libs/cms-plugin/src/collections/brands/home-link.ts
+++ b/libs/cms-plugin/src/collections/brands/home-link.ts
@@ -71,10 +71,6 @@ export async function syncBrandHomeLink({
   });
 
   const homePage = homePages.docs[0];
-  const locale = req.payload.config.localization
-    ? req.payload.config.localization.defaultLocale
-    : req.locale;
-
   await req.payload.update({
     id: brandId,
     collection: "brands",
@@ -86,7 +82,7 @@ export async function syncBrandHomeLink({
           }
         : {},
     },
-    locale,
+    locale: "en",
     overrideAccess: true,
     req,
   });

--- a/libs/cms-plugin/src/collections/brands/root-path.ts
+++ b/libs/cms-plugin/src/collections/brands/root-path.ts
@@ -12,6 +12,14 @@ import {
 } from "../../common/pathname.js";
 import { textField } from "../../fields/text.js";
 
+export type LocalizedRootPath = Record<string, string>;
+type TextValidationOptions = ValidateOptions<
+  unknown,
+  unknown,
+  TextField,
+  string
+>;
+
 export function rootPathField() {
   return textField({
     name: "rootPath",
@@ -23,10 +31,7 @@ export function rootPathField() {
       placeholder: "e.g. /brand-name",
     },
     hooks: {
-      beforeValidate: [
-        ({ value }) =>
-          typeof value === "string" ? normalizePathnameInput(value) : value,
-      ],
+      beforeValidate: [({ value }) => normalizeRootPathValue(value)],
     },
     label: {
       en: "Root Path",
@@ -37,21 +42,54 @@ export function rootPathField() {
 }
 
 async function validateRootPath(
-  value: null | string | undefined,
+  value: LocalizedRootPath | null | string | undefined,
   options: ValidateOptions<
     Record<string, unknown>,
     Record<string, unknown>,
     TextField,
-    string
+    LocalizedRootPath | string
   >,
 ) {
-  const defaultValidationResult = text(value, options);
+  const values = getRootPathValuesForValidation(value);
+  const textValidationOptions = options as unknown as TextValidationOptions;
+
+  if (values === null) {
+    return text(undefined, textValidationOptions);
+  }
+
+  if (typeof values === "string") {
+    return validateRootPathValue(values, options);
+  }
+
+  for (const rootPath of Object.values(values)) {
+    const validationResult = await validateRootPathValue(rootPath, options);
+    if (validationResult !== true) {
+      return validationResult;
+    }
+  }
+
+  return true;
+}
+
+async function validateRootPathValue(
+  value: string,
+  options: ValidateOptions<
+    Record<string, unknown>,
+    Record<string, unknown>,
+    TextField,
+    LocalizedRootPath | string
+  >,
+) {
+  const defaultValidationResult = text(
+    value,
+    options as unknown as TextValidationOptions,
+  );
   if (defaultValidationResult !== true) {
     return defaultValidationResult;
   }
 
   const t = options.req.t as unknown as TFunction<TranslationsKey>;
-  const rootPath = normalizePathnameInput(value ?? "");
+  const rootPath = normalizePathnameInput(value);
   const formatValidationResult = validateRootPathFormat(rootPath);
 
   if (formatValidationResult !== true) {
@@ -66,6 +104,44 @@ async function validateRootPath(
   }
 
   return true;
+}
+
+export function normalizeRootPathValue(value: unknown) {
+  if (typeof value === "string") {
+    return normalizePathnameInput(value);
+  }
+
+  if (!isPlainObject(value)) {
+    return value;
+  }
+
+  return Object.fromEntries(
+    Object.entries(value).map(([localeId, localizedValue]) => [
+      localeId,
+      typeof localizedValue === "string"
+        ? normalizePathnameInput(localizedValue)
+        : localizedValue,
+    ]),
+  );
+}
+
+export function resolveRootPathForLocale(
+  rootPath: unknown,
+  localeId: string | undefined,
+) {
+  if (typeof rootPath === "string") {
+    return normalizePathnameInput(rootPath);
+  }
+
+  if (!localeId || !isPlainObject(rootPath)) {
+    return undefined;
+  }
+
+  const localizedRootPath = rootPath[localeId];
+
+  return typeof localizedRootPath === "string"
+    ? normalizePathnameInput(localizedRootPath)
+    : undefined;
 }
 
 export async function getBrandsWithOverlappingRootPath(
@@ -98,19 +174,15 @@ export function rootPathsOverlap(rootPathA: string, rootPathB: string) {
   );
 }
 
-function getLocalizedRootPaths(rootPath: unknown, localeIds: string[]) {
-  if (typeof rootPath === "string") {
-    return [rootPath];
-  }
-
-  if (!rootPath || typeof rootPath !== "object" || Array.isArray(rootPath)) {
+export function getLocalizedRootPaths(rootPath: unknown, localeIds: string[]) {
+  if (!isPlainObject(rootPath)) {
     return [];
   }
 
   return localeIds.flatMap((localeId) => {
-    const localizedRootPath = (rootPath as Record<string, unknown>)[localeId];
+    const localizedRootPath = resolveRootPathForLocale(rootPath, localeId);
 
-    return typeof localizedRootPath === "string" ? [localizedRootPath] : [];
+    return localizedRootPath ? [localizedRootPath] : [];
   });
 }
 
@@ -132,4 +204,32 @@ export async function getPublishedLocaleIds(req: PayloadRequest) {
   return publishedLocales
     .map((locale) => (typeof locale === "string" ? locale : locale.id))
     .filter((localeId): localeId is string => Boolean(localeId));
+}
+
+function getRootPathValuesForValidation(
+  value: LocalizedRootPath | null | string | undefined,
+) {
+  if (typeof value === "string") {
+    return normalizePathnameInput(value);
+  }
+
+  if (isLocalizedRootPath(value)) {
+    return value;
+  }
+
+  return null;
+}
+
+function isLocalizedRootPath(value: unknown): value is LocalizedRootPath {
+  return (
+    isPlainObject(value) &&
+    Object.keys(value).length > 0 &&
+    Object.values(value).every((localizedValue) => {
+      return typeof localizedValue === "string";
+    })
+  );
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return Boolean(value && typeof value === "object" && !Array.isArray(value));
 }

--- a/libs/cms-plugin/src/collections/pages/config.ts
+++ b/libs/cms-plugin/src/collections/pages/config.ts
@@ -23,6 +23,7 @@ import { textField } from "../../fields/text.js";
 import { textareaField } from "../../fields/textarea.js";
 import { contentGroup } from "../../groups.js";
 import { getPageBrandId, syncBrandHomeLink } from "../brands/home-link.js";
+import { resolveRootPathForLocale } from "../brands/root-path.js";
 import {
   getLocalizedPathnameEndpoint,
   getPagesForPathname,
@@ -268,8 +269,14 @@ export function Pages({
             },
           });
 
-          const brandRootPath =
-            typeof brand.rootPath === "string" ? brand.rootPath : undefined;
+          const localization = req.payload.config.localization;
+          const locale =
+            req.locale ??
+            (localization ? localization.defaultLocale : undefined);
+          const brandRootPath = resolveRootPathForLocale(
+            brand.rootPath,
+            locale,
+          );
           const pageRelationship = brand.homeLink as
             | Record<string, unknown>
             | undefined;

--- a/libs/cms-plugin/tests/collections/brands/home-link.test.ts
+++ b/libs/cms-plugin/tests/collections/brands/home-link.test.ts
@@ -29,4 +29,8 @@ describe("brand home link helpers", () => {
       ),
     ).toEqual([{ localeId: "en", rootPath: "/brand" }]);
   });
+
+  it("ignores scalar root paths in locale-all helpers", () => {
+    expect(getRootPathsByLocale("/brand", ["en", "es"])).toEqual([]);
+  });
 });

--- a/libs/cms-plugin/tests/collections/brands/root-path.test.ts
+++ b/libs/cms-plugin/tests/collections/brands/root-path.test.ts
@@ -1,6 +1,45 @@
 import { describe, expect, it } from "vitest";
 
-import { rootPathsOverlap } from "../../../src/collections/brands/root-path.js";
+import {
+  normalizeRootPathValue,
+  resolveRootPathForLocale,
+  rootPathField,
+  rootPathsOverlap,
+} from "../../../src/collections/brands/root-path.js";
+
+function createValidateOptions({
+  docs = [],
+  id = "current-brand",
+}: {
+  docs?: { id: string; rootPath: unknown }[];
+  id?: string;
+} = {}) {
+  return {
+    id,
+    required: true,
+    req: {
+      payload: {
+        config: {},
+        find: async () => ({ docs }),
+        findGlobal: async () => ({
+          publishedLocales: {
+            publishedLocales: ["en", "es"],
+          },
+        }),
+      },
+      t: (key: string) => key,
+    },
+  } as never;
+}
+
+async function validateRootPath(
+  value: unknown,
+  options = createValidateOptions(),
+) {
+  const field = rootPathField();
+
+  return field.validate!(value as never, options);
+}
 
 describe("brand root path helpers", () => {
   it("detects equal root paths as overlapping", () => {
@@ -18,5 +57,64 @@ describe("brand root path helpers", () => {
 
   it("does not treat sibling path prefixes as overlapping", () => {
     expect(rootPathsOverlap("/brand", "/brandish")).toBe(false);
+  });
+
+  it("normalizes active-locale root path strings", () => {
+    expect(normalizeRootPathValue(" /brand ")).toBe("/brand");
+  });
+
+  it("normalizes localized root path values", () => {
+    expect(
+      normalizeRootPathValue({
+        en: " /brand ",
+        es: " /marca ",
+      }),
+    ).toEqual({
+      en: "/brand",
+      es: "/marca",
+    });
+  });
+
+  it("resolves root paths for the requested locale", () => {
+    expect(
+      resolveRootPathForLocale(
+        {
+          en: "/brand",
+          es: "/marca",
+        },
+        "es",
+      ),
+    ).toBe("/marca");
+  });
+
+  it("supports active-locale string root path validation", async () => {
+    await expect(validateRootPath("/brand")).resolves.toBe(true);
+  });
+
+  it("supports localized root path validation", async () => {
+    await expect(
+      validateRootPath({
+        en: "/brand",
+        es: "/marca",
+      }),
+    ).resolves.toBe(true);
+  });
+
+  it("rejects malformed localized root path values", async () => {
+    await expect(
+      validateRootPath({
+        en: "/brand",
+        es: "marca",
+      }),
+    ).resolves.toBe("cmsPlugin:brands:rootPath:mustStartWithSlash");
+  });
+
+  it("rejects malformed localized root path objects", async () => {
+    await expect(
+      validateRootPath({
+        en: "/brand",
+        es: null,
+      }),
+    ).resolves.toBe("validation:required");
   });
 });


### PR DESCRIPTION
## Summary
- keep brand `rootPath` as a localized-only persisted shape while still supporting active-locale string values in field hooks
- centralize root-path normalization, validation, and locale resolution helpers
- update live preview, page pathname validation, and home-link sync to use explicit locale-aware root-path handling

## Root cause
`rootPath` is a localized Payload text field, but parts of the cms-plugin treated locale-all data and active-locale data interchangeably. That could allow scalar root-path values to leak into paths where Mongo expects the localized object shape.

## Risk and mitigation
- The `homeLink` sync update now writes with `locale: "en"`, matching the plugin localization default, so the internal update no longer runs through `locale=all`.
- Locale-all helpers intentionally ignore scalar root paths so malformed persisted data is not silently accepted.
- Added focused tests for active-locale strings, localized root-path objects, invalid localized objects, locale resolution, and scalar rejection in locale-all helpers.

## Validation
- `pnpm --filter cms-plugin test:int`
- `pnpm --filter cms-plugin build`
- `pnpm --filter cms-plugin lint` (passes with existing warnings only)
- `pnpm --filter cms-example build`
- `pnpm format:check`
- `pnpm check`

## Follow-ups
- Downstream direct Mongo seed data, such as lapuertahostels e2e fixtures, should store localized `rootPath` objects rather than scalar strings.