### PR TITLE
ci(cms-example): fix Fly Dockerfile path

### DIFF
--- a/examples/cms-example/fly.build.toml
+++ b/examples/cms-example/fly.build.toml
@@ -2,4 +2,4 @@
 # does not seem to work reliably without specifying a config file)
 
 [build]
-  dockerfile = 'examples/cms-example/Dockerfile'
+  dockerfile = 'Dockerfile'


### PR DESCRIPTION
## Summary

- Update the cms-example Fly build config to reference the Dockerfile relative to `examples/cms-example/fly.build.toml`.
- Fix the merged `main` build failure where Fly tried to resolve `examples/cms-example/examples/cms-example/Dockerfile`.

## Validation

- `pnpm format:check`
- `git diff --check`

Note: `flyctl config validate` could not be completed locally because the sandbox has no Fly access token, but the failing Actions log confirms the path resolution issue.