### PR TITLE
fix(cms-plugin): allow editors to create brands

### DIFF
--- a/libs/cms-plugin/src/collections/brands/config.ts
+++ b/libs/cms-plugin/src/collections/brands/config.ts
@@ -27,7 +27,7 @@ export function Brands({
   return {
     slug: "brands",
     access: {
-      create: ({ req }) => isAdmin(req),
+      create: canManageContent,
       delete: ({ req }) => isAdmin(req),
       update: canManageContent,
     },

--- a/libs/cms-plugin/tests/collections/brands/access.test.ts
+++ b/libs/cms-plugin/tests/collections/brands/access.test.ts
@@ -1,0 +1,47 @@
+import type { Access, PayloadRequest } from "payload";
+
+import { describe, expect, it } from "vitest";
+
+import { Brands } from "../../../src/collections/brands/config.js";
+
+function brandCreateAccess() {
+  return Brands({}).access?.create as Access;
+}
+
+function reqWithUser(user?: PayloadRequest["user"]): PayloadRequest {
+  return { user } as PayloadRequest;
+}
+
+describe("brand access", () => {
+  it("allows editors to create brands", () => {
+    expect(
+      brandCreateAccess()({
+        req: reqWithUser({ collection: "users", role: "editor" }),
+      }),
+    ).toBe(true);
+  });
+
+  it("allows admins to create brands", () => {
+    expect(
+      brandCreateAccess()({
+        req: reqWithUser({ collection: "users", role: "admin" }),
+      }),
+    ).toBe(true);
+  });
+
+  it("rejects anonymous brand creation", () => {
+    expect(
+      brandCreateAccess()({
+        req: reqWithUser(),
+      }),
+    ).toBe(false);
+  });
+
+  it("rejects brand creation from non-user auth collections", () => {
+    expect(
+      brandCreateAccess()({
+        req: reqWithUser({ collection: "api-keys", role: "frontend" }),
+      }),
+    ).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

- Allow `editor` users to create brand records by using the shared content-management access helper.
- Keep brand deletion admin-only.
- Add focused Vitest coverage for brand create access by role/auth collection.

## Validation

- `pnpm --filter cms-plugin test:int`
- `pnpm --filter cms-plugin lint` (passes with existing warnings)