### PR TITLE
fix(cms-example): include runtime DOM deps

### DIFF
--- a/examples/cms-example/package.json
+++ b/examples/cms-example/package.json
@@ -24,7 +24,9 @@
     "@payloadcms/richtext-lexical": "3.84.1",
     "@payloadcms/storage-s3": "3.84.1",
     "@payloadcms/ui": "3.84.1",
+    "bson": "^6.10.4",
     "cross-env": "^10.1.0",
+    "jsdom": "29.1.1",
     "next": "16.2.6",
     "payload": "3.84.1",
     "react": "19.2.6"

--- a/libs/cms-plugin/package.json
+++ b/libs/cms-plugin/package.json
@@ -33,12 +33,10 @@
     "@types/node": "^24.12.4",
     "@types/react": "19.2.15",
     "@types/react-dom": "19.2.3",
-    "bson": "^6.10.4",
     "copyfiles": "2.4.1",
     "cross-env": "^10.1.0",
     "eslint": "^10.4.0",
     "eslint-config-next": "16.2.6",
-    "jsdom": "29.1.1",
     "next": "16.2.6",
     "payload": "3.84.1",
     "prettier": "^3.8.3",
@@ -55,8 +53,6 @@
   },
   "peerDependencies": {
     "@payloadcms/db-mongodb": "^3.84.1",
-    "bson": "^6.10.4",
-    "jsdom": "29.1.1",
     "next": ">=16.2.2 <17.0.0",
     "payload": "^3.84.1",
     "react": "^18 || ^19",
@@ -67,7 +63,9 @@
   },
   "dependencies": {
     "@payloadcms/translations": "3.84.1",
+    "bson": "^6.10.4",
     "deepl-node": "^1.27.0",
+    "jsdom": "29.1.1",
     "openai": "^6.38.0",
     "zod": "^4.4.3"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -83,9 +83,15 @@ importers:
       '@payloadcms/ui':
         specifier: 3.84.1
         version: 3.84.1(@types/react@19.2.15)(monaco-editor@0.52.2)(next@16.2.6(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.77.4))(payload@3.84.1(graphql@16.11.0)(typescript@6.0.3))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(typescript@6.0.3)
+      bson:
+        specifier: ^6.10.4
+        version: 6.10.4
       cross-env:
         specifier: ^10.1.0
         version: 10.1.0
+      jsdom:
+        specifier: 29.1.1
+        version: 29.1.1
       next:
         specifier: 16.2.6
         version: 16.2.6(@babel/core@7.29.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.77.4)
@@ -126,9 +132,15 @@ importers:
       '@payloadcms/translations':
         specifier: 3.84.1
         version: 3.84.1
+      bson:
+        specifier: ^6.10.4
+        version: 6.10.4
       deepl-node:
         specifier: ^1.27.0
         version: 1.27.0
+      jsdom:
+        specifier: 29.1.1
+        version: 29.1.1
       openai:
         specifier: ^6.38.0
         version: 6.38.0(ws@8.20.1)(zod@4.4.3)
@@ -172,9 +184,6 @@ importers:
       '@types/react-dom':
         specifier: 19.2.3
         version: 19.2.3(@types/react@19.2.15)
-      bson:
-        specifier: ^6.10.4
-        version: 6.10.4
       copyfiles:
         specifier: 2.4.1
         version: 2.4.1
@@ -187,9 +196,6 @@ importers:
       eslint-config-next:
         specifier: 16.2.6
         version: 16.2.6(@typescript-eslint/parser@8.59.4(eslint@10.4.0(jiti@2.5.1))(typescript@6.0.3))(eslint-plugin-import-x@4.6.1(eslint@10.4.0(jiti@2.5.1))(typescript@6.0.3))(eslint@10.4.0(jiti@2.5.1))(typescript@6.0.3)
-      jsdom:
-        specifier: 29.1.1
-        version: 29.1.1
       next:
         specifier: 16.2.6
         version: 16.2.6(@babel/core@7.29.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.77.4)


### PR DESCRIPTION
## Summary

- Move `jsdom` and `bson` into `@fxmk/cms-plugin` runtime dependencies because the plugin imports them in server endpoint code.
- Add `jsdom` and `bson` to `cms-example` dependencies so Next standalone runtime externals can resolve them in staging.
- Update the pnpm lockfile for the dependency graph change.

## Root Cause

The plugin endpoint imports `jsdom` at runtime, while `cms-example` externalizes `jsdom` from the Next standalone bundle. The staging server therefore tried to resolve `jsdom` at runtime, but the package was only available as a plugin dev/peer dependency and was not present from the standalone server path.

## Validation

- `pnpm --filter common build`
- `pnpm --filter cms-plugin build`
- `pnpm --filter cms-example build`
- Verified `require.resolve("jsdom")` and `require.resolve("bson")` from the generated standalone server path.