### PR TITLE
ci: run cms-example image build on trusted PRs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -72,29 +72,12 @@ jobs:
           name: common-dist
           path: libs/common/dist
 
-  cms-example-build:
-    name: "cms-example: Build"
-    runs-on: ubuntu-latest
-    needs: [cms-plugin-build]
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v6
-      - name: Setup
-        uses: ./.github/actions/setup
-      - name: Download cms-plugin 'dist' directory
-        uses: actions/download-artifact@v8
-        with:
-          name: cms-plugin-dist
-          path: libs/cms-plugin/dist
-      - name: Install dependencies
-        run: pnpm --filter cms-example --filter cms-plugin install
-      - name: Build
-        run: pnpm --filter cms-example build
-
   cms-example-build-push:
     name: "cms-example: Build and Push"
     runs-on: ubuntu-latest
-    if: github.event_name != 'pull_request' && github.ref == 'refs/heads/main'
+    if: >
+      github.ref == 'refs/heads/main' || (github.event_name == 'pull_request' &&
+        github.event.pull_request.head.repo.full_name == github.repository)
     needs: [version]
     outputs:
       image: ${{ steps.image-name.outputs.image }}
@@ -193,7 +176,6 @@ jobs:
       - quality
       - cms-plugin-build
       - common-build
-      - cms-example-build
       - cms-example-image-ready
     environment:
       name: staging-cms-example
@@ -242,7 +224,7 @@ jobs:
       - quality
       - cms-plugin-build
       - common-build
-      - cms-example-build
+      - cms-example-build-push
       - version
     if: needs.version.outputs.is_new_release == 'true'
     permissions:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -77,6 +77,7 @@ jobs:
     runs-on: ubuntu-latest
     if: >
       github.ref == 'refs/heads/main' || (github.event_name == 'pull_request' &&
+        github.actor != 'dependabot[bot]' &&
         github.event.pull_request.head.repo.full_name == github.repository)
     needs: [version]
     outputs:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -115,6 +115,19 @@ jobs:
         env:
           FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
 
+  cms-example-build-image:
+    name: "cms-example: Build Image"
+    runs-on: ubuntu-latest
+    if: >
+      github.event_name == 'pull_request' && (github.actor == 'dependabot[bot]'
+      ||
+        github.event.pull_request.head.repo.full_name != github.repository)
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+      - name: Build cms-example Docker image
+        run: docker build -f examples/cms-example/Dockerfile .
+
   cms-example-image-ready:
     name: "cms-example: Image Ready"
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- remove the standalone cms-example build-only job
- run the cms-example build-and-push image job on main and same-repository PRs
- keep image readiness and deploy restricted to main
- use the image build as the cms-example release gate

## Validation
- pnpm format:check
- git diff --check