### PR TITLE
fix(cms-example): update Payload import map

### DIFF
--- a/examples/cms-example/src/app/(payload)/admin/importMap.js
+++ b/examples/cms-example/src/app/(payload)/admin/importMap.js
@@ -22,7 +22,9 @@ import { PathnameField as PathnameField_4e4d92471a8ffe9293251f3f72fec394 } from 
 import { ToCell as ToCell_4e4d92471a8ffe9293251f3f72fec394 } from '@fxmk/cms-plugin/client'
 import { VersionInfo as VersionInfo_28fa94cce12a23e7fb2af3fe07ac7e9a } from '@fxmk/cms-plugin/rsc'
 import { S3ClientUploadHandler as S3ClientUploadHandler_f97aa6c64367fa259c5bc0567239ef24 } from '@payloadcms/storage-s3/client'
+import { CollectionCards as CollectionCards_f9c02e79a4aed9a3924487c0cd4cafb1 } from '@payloadcms/next/rsc'
 
+/** @type import('payload').ImportMap */
 export const importMap = {
   "@fxmk/cms-plugin/client#TranslationsFieldLabel": TranslationsFieldLabel_4e4d92471a8ffe9293251f3f72fec394,
   "@fxmk/cms-plugin/client#GenerateAltTextButton": GenerateAltTextButton_4e4d92471a8ffe9293251f3f72fec394,
@@ -47,5 +49,6 @@ export const importMap = {
   "@fxmk/cms-plugin/client#PathnameField": PathnameField_4e4d92471a8ffe9293251f3f72fec394,
   "@fxmk/cms-plugin/client#ToCell": ToCell_4e4d92471a8ffe9293251f3f72fec394,
   "@fxmk/cms-plugin/rsc#VersionInfo": VersionInfo_28fa94cce12a23e7fb2af3fe07ac7e9a,
-  "@payloadcms/storage-s3/client#S3ClientUploadHandler": S3ClientUploadHandler_f97aa6c64367fa259c5bc0567239ef24
+  "@payloadcms/storage-s3/client#S3ClientUploadHandler": S3ClientUploadHandler_f97aa6c64367fa259c5bc0567239ef24,
+  "@payloadcms/next/rsc#CollectionCards": CollectionCards_f9c02e79a4aed9a3924487c0cd4cafb1
 }


### PR DESCRIPTION
## Summary

- Regenerate the cms-example Payload import map for Payload 3.84.x.
- Add the missing `@payloadcms/next/rsc#CollectionCards` mapping that Payload now expects for the default admin dashboard widget.

## Root Cause

The checked-in import map was stale after the Payload version started sanitizing the default dashboard widget as `@payloadcms/next/rsc#CollectionCards`. At startup, Payload tried to resolve that component through the import map and logged `PayloadComponent not found in importMap`.

## Validation

- `pnpm --filter cms-example generate:importmap`
- `pnpm --filter cms-example lint`
- Smoke-started `pnpm --filter cms-example dev`; Next reached `Ready`, then the local watcher emitted unrelated `EMFILE: too many open files` warnings.