### PR TITLE
fix(cms-plugin): preserve request locale during brand lookups

### DIFF
--- a/libs/cms-plugin/src/collections/brands/home-link.ts
+++ b/libs/cms-plugin/src/collections/brands/home-link.ts
@@ -1,6 +1,7 @@
 import type { PayloadRequest } from "payload";
 
 import {
+  createIsolatedLocalRequest,
   getPublishedLocaleIds,
   resolveRootPathForLocale,
 } from "./root-path.js";
@@ -37,7 +38,7 @@ export async function syncBrandHomeLink({
     id: brandId,
     collection: "brands",
     locale: "all",
-    req,
+    req: createIsolatedLocalRequest(req),
     select: {
       rootPath: true,
     },

--- a/libs/cms-plugin/src/collections/brands/root-path.ts
+++ b/libs/cms-plugin/src/collections/brands/root-path.ts
@@ -154,7 +154,7 @@ export async function getBrandsWithOverlappingRootPath(
     collection: "brands",
     locale: "all",
     pagination: false,
-    req,
+    req: createIsolatedLocalRequest(req),
     select: {
       rootPath: true,
     },
@@ -232,4 +232,22 @@ function isLocalizedRootPath(value: unknown): value is LocalizedRootPath {
 
 function isPlainObject(value: unknown): value is Record<string, unknown> {
   return Boolean(value && typeof value === "object" && !Array.isArray(value));
+}
+
+export function createIsolatedLocalRequest(
+  req: PayloadRequest,
+): PayloadRequest {
+  const isolatedReq = Object.create(req) as PayloadRequest;
+
+  isolatedReq.context = { ...(req.context ?? {}) };
+  isolatedReq.query = { ...(req.query ?? {}) };
+  isolatedReq.routeParams = req.routeParams ? { ...req.routeParams } : {};
+  Object.defineProperty(isolatedReq, "payloadDataLoader", {
+    configurable: true,
+    enumerable: true,
+    value: undefined,
+    writable: true,
+  });
+
+  return isolatedReq;
 }

--- a/libs/cms-plugin/tests/collections/brands/root-path.test.ts
+++ b/libs/cms-plugin/tests/collections/brands/root-path.test.ts
@@ -1,6 +1,9 @@
+import type { PayloadRequest } from "payload";
+
 import { describe, expect, it } from "vitest";
 
 import {
+  getBrandsWithOverlappingRootPath,
   normalizeRootPathValue,
   resolveRootPathForLocale,
   rootPathField,
@@ -116,5 +119,47 @@ describe("brand root path helpers", () => {
         es: null,
       }),
     ).resolves.toBe("validation:required");
+  });
+
+  it("preserves the request locale while checking all localized root paths", async () => {
+    let localAPIReq: PayloadRequest | undefined;
+    const req = {
+      locale: "en",
+      payload: {
+        findGlobal: async () => ({
+          publishedLocales: {
+            publishedLocales: ["en", "es"],
+          },
+        }),
+        find: async (options: { req: PayloadRequest }) => {
+          localAPIReq = options.req;
+          options.req.locale = "all";
+
+          return {
+            docs: [
+              {
+                id: "brand",
+                rootPath: {
+                  en: "/existing",
+                  es: "/existente",
+                },
+              },
+            ],
+          };
+        },
+      },
+    } as unknown as PayloadRequest;
+
+    await getBrandsWithOverlappingRootPath(req, "/new");
+
+    expect(localAPIReq).toBeDefined();
+    if (!localAPIReq) {
+      throw new Error("Expected the nested brand lookup to run");
+    }
+
+    expect(localAPIReq).not.toBe(req);
+    expect(Object.getPrototypeOf(localAPIReq)).toBe(req);
+    expect(localAPIReq.locale).toBe("all");
+    expect(req.locale).toBe("en");
   });
 });


### PR DESCRIPTION
## Summary

- pass an isolated local API request into internal brand lookups that intentionally use `locale: "all"`
- apply the same isolation to brand home-link sync reads
- add a regression test that simulates Payload mutating the local API request without affecting the outer validation request

## Root Cause

Brand creation validates localized `rootPath` values by querying existing brands with `locale: "all"`. Payload's local API runs those calls through `createLocalReq`, which mutates the request object it receives by assigning `req.locale` from the operation options.

When the live admin create request is reused for that nested lookup, it can be changed to `req.locale = "all"`. The outer create operation then reaches localized field handling with the special `all` locale instead of the actual admin locale, so localized text fields like `rootPath` and `baseTitle` remain raw strings. Mongo/Mongoose expects embedded locale objects for those fields and raises the `Cast to Embedded failed` validation error.

The fix keeps the nested all-locale read, but gives it an isolated request object. That preserves user, transaction, headers, context, and query information needed by the local API while preventing Payload's local request normalization from changing the outer request.

## Validation

- `CI=true pnpm --filter @fxmk/cms-plugin test:int -- tests/collections/brands/root-path.test.ts`
- `CI=true pnpm --filter @fxmk/cms-plugin build`
- `CI=true pnpm --filter @fxmk/cms-plugin lint` (passes with existing warnings only)