### PR TITLE
fix(cms-example): redirect root to admin

### DIFF
--- a/examples/cms-example/next.config.mjs
+++ b/examples/cms-example/next.config.mjs
@@ -9,6 +9,9 @@ const dirname = path.dirname(filename);
 const nextConfig = {
   output: "standalone",
   outputFileTracingRoot: path.join(dirname, "../.."),
+  async redirects() {
+    return [{ source: "/", destination: "/admin", permanent: false }];
+  },
   serverExternalPackages: ["jsdom"],
   webpack: (webpackConfig, { isServer }) => {
     if (isServer) {


### PR DESCRIPTION
## Summary
- Redirect the cms-example root path `/` to `/admin` via Next.js config.
- Match the non-permanent redirect pattern used by the lapuertahostels CMS.
- Leave generated Payload app files unchanged.

## Validation
- `pnpm --filter @fxmk/cms-example lint`
- `pnpm --filter @fxmk/cms-example build`

Note: the build completed successfully after reporting non-blocking compile warnings.