### PR TITLE
feat(cms-example): enable media folders

### DIFF
--- a/examples/cms-example/README.md
+++ b/examples/cms-example/README.md
@@ -118,7 +118,9 @@ docs for details on how to extend this functionality.
 - #### Media
 
   This is the uploads enabled collection. It features pre-configured sizes,
-  focal point and manual resizing to help you manage your pictures.
+  focal point and manual resizing to help you manage your pictures. Media uses
+  Payload's native folders feature, including the browse-by-folder admin view,
+  to organize uploads.
 
 ### Docker
 

--- a/examples/cms-example/src/app/(payload)/admin/importMap.js
+++ b/examples/cms-example/src/app/(payload)/admin/importMap.js
@@ -1,6 +1,8 @@
 import { TranslationsFieldLabel as TranslationsFieldLabel_4e4d92471a8ffe9293251f3f72fec394 } from '@fxmk/cms-plugin/client'
 import { GenerateAltTextButton as GenerateAltTextButton_4e4d92471a8ffe9293251f3f72fec394 } from '@fxmk/cms-plugin/client'
 import { UsagesField as UsagesField_28fa94cce12a23e7fb2af3fe07ac7e9a } from '@fxmk/cms-plugin/rsc'
+import { FolderTableCell as FolderTableCell_f9c02e79a4aed9a3924487c0cd4cafb1 } from '@payloadcms/next/rsc'
+import { FolderField as FolderField_f9c02e79a4aed9a3924487c0cd4cafb1 } from '@payloadcms/next/rsc'
 import { RscEntryLexicalCell as RscEntryLexicalCell_44fe37237e0ebf4470c9990d8cb7b07e } from '@payloadcms/richtext-lexical/rsc'
 import { RscEntryLexicalField as RscEntryLexicalField_44fe37237e0ebf4470c9990d8cb7b07e } from '@payloadcms/richtext-lexical/rsc'
 import { LexicalDiffComponent as LexicalDiffComponent_44fe37237e0ebf4470c9990d8cb7b07e } from '@payloadcms/richtext-lexical/rsc'
@@ -20,6 +22,7 @@ import { RowLabel as RowLabel_4e4d92471a8ffe9293251f3f72fec394 } from '@fxmk/cms
 import { DescriptionField as DescriptionField_28fa94cce12a23e7fb2af3fe07ac7e9a } from '@fxmk/cms-plugin/rsc'
 import { PathnameField as PathnameField_4e4d92471a8ffe9293251f3f72fec394 } from '@fxmk/cms-plugin/client'
 import { ToCell as ToCell_4e4d92471a8ffe9293251f3f72fec394 } from '@fxmk/cms-plugin/client'
+import { FolderTypeField as FolderTypeField_2b8867833a34864a02ddf429b0728a40 } from '@payloadcms/next/client'
 import { VersionInfo as VersionInfo_28fa94cce12a23e7fb2af3fe07ac7e9a } from '@fxmk/cms-plugin/rsc'
 import { S3ClientUploadHandler as S3ClientUploadHandler_f97aa6c64367fa259c5bc0567239ef24 } from '@payloadcms/storage-s3/client'
 import { CollectionCards as CollectionCards_f9c02e79a4aed9a3924487c0cd4cafb1 } from '@payloadcms/next/rsc'
@@ -29,6 +32,8 @@ export const importMap = {
   "@fxmk/cms-plugin/client#TranslationsFieldLabel": TranslationsFieldLabel_4e4d92471a8ffe9293251f3f72fec394,
   "@fxmk/cms-plugin/client#GenerateAltTextButton": GenerateAltTextButton_4e4d92471a8ffe9293251f3f72fec394,
   "@fxmk/cms-plugin/rsc#UsagesField": UsagesField_28fa94cce12a23e7fb2af3fe07ac7e9a,
+  "@payloadcms/next/rsc#FolderTableCell": FolderTableCell_f9c02e79a4aed9a3924487c0cd4cafb1,
+  "@payloadcms/next/rsc#FolderField": FolderField_f9c02e79a4aed9a3924487c0cd4cafb1,
   "@payloadcms/richtext-lexical/rsc#RscEntryLexicalCell": RscEntryLexicalCell_44fe37237e0ebf4470c9990d8cb7b07e,
   "@payloadcms/richtext-lexical/rsc#RscEntryLexicalField": RscEntryLexicalField_44fe37237e0ebf4470c9990d8cb7b07e,
   "@payloadcms/richtext-lexical/rsc#LexicalDiffComponent": LexicalDiffComponent_44fe37237e0ebf4470c9990d8cb7b07e,
@@ -48,6 +53,7 @@ export const importMap = {
   "@fxmk/cms-plugin/rsc#DescriptionField": DescriptionField_28fa94cce12a23e7fb2af3fe07ac7e9a,
   "@fxmk/cms-plugin/client#PathnameField": PathnameField_4e4d92471a8ffe9293251f3f72fec394,
   "@fxmk/cms-plugin/client#ToCell": ToCell_4e4d92471a8ffe9293251f3f72fec394,
+  "@payloadcms/next/client#FolderTypeField": FolderTypeField_2b8867833a34864a02ddf429b0728a40,
   "@fxmk/cms-plugin/rsc#VersionInfo": VersionInfo_28fa94cce12a23e7fb2af3fe07ac7e9a,
   "@payloadcms/storage-s3/client#S3ClientUploadHandler": S3ClientUploadHandler_f97aa6c64367fa259c5bc0567239ef24,
   "@payloadcms/next/rsc#CollectionCards": CollectionCards_f9c02e79a4aed9a3924487c0cd4cafb1

--- a/examples/cms-example/src/payload-types.ts
+++ b/examples/cms-example/src/payload-types.ts
@@ -69,7 +69,6 @@ export interface Config {
   blocks: {};
   collections: {
     media: Media;
-    mediaCategory: MediaCategory;
     users: User;
     'api-keys': ApiKey;
     'locale-configs': LocaleConfig;
@@ -78,18 +77,18 @@ export interface Config {
     redirects: Redirect;
     brands: Brand;
     'payload-kv': PayloadKv;
+    'payload-folders': FolderInterface;
     'payload-locked-documents': PayloadLockedDocument;
     'payload-preferences': PayloadPreference;
     'payload-migrations': PayloadMigration;
   };
   collectionsJoins: {
-    mediaCategory: {
-      media: 'media';
+    'payload-folders': {
+      documentsAndFolders: 'payload-folders' | 'media';
     };
   };
   collectionsSelect: {
     media: MediaSelect<false> | MediaSelect<true>;
-    mediaCategory: MediaCategorySelect<false> | MediaCategorySelect<true>;
     users: UsersSelect<false> | UsersSelect<true>;
     'api-keys': ApiKeysSelect<false> | ApiKeysSelect<true>;
     'locale-configs': LocaleConfigsSelect<false> | LocaleConfigsSelect<true>;
@@ -98,6 +97,7 @@ export interface Config {
     redirects: RedirectsSelect<false> | RedirectsSelect<true>;
     brands: BrandsSelect<false> | BrandsSelect<true>;
     'payload-kv': PayloadKvSelect<false> | PayloadKvSelect<true>;
+    'payload-folders': PayloadFoldersSelect<false> | PayloadFoldersSelect<true>;
     'payload-locked-documents': PayloadLockedDocumentsSelect<false> | PayloadLockedDocumentsSelect<true>;
     'payload-preferences': PayloadPreferencesSelect<false> | PayloadPreferencesSelect<true>;
     'payload-migrations': PayloadMigrationsSelect<false> | PayloadMigrationsSelect<true>;
@@ -593,9 +593,9 @@ export interface ApiKeyAuthOperations {
  */
 export interface Media {
   id: string;
-  category?: (string | null) | MediaCategory;
   comment?: string | null;
   alt?: string | null;
+  folder?: (string | null) | FolderInterface;
   updatedAt: string;
   createdAt: string;
   url?: string | null;
@@ -620,16 +620,27 @@ export interface Media {
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema
- * via the `definition` "mediaCategory".
+ * via the `definition` "payload-folders".
  */
-export interface MediaCategory {
+export interface FolderInterface {
   id: string;
   name: string;
-  media?: {
-    docs?: (string | Media)[];
+  folder?: (string | null) | FolderInterface;
+  documentsAndFolders?: {
+    docs?: (
+      | {
+          relationTo?: 'payload-folders';
+          value: string | FolderInterface;
+        }
+      | {
+          relationTo?: 'media';
+          value: string | Media;
+        }
+    )[];
     hasNextPage?: boolean;
     totalDocs?: number;
   };
+  folderType?: 'media'[] | null;
   updatedAt: string;
   createdAt: string;
 }
@@ -1653,10 +1664,6 @@ export interface PayloadLockedDocument {
         value: string | Media;
       } | null)
     | ({
-        relationTo: 'mediaCategory';
-        value: string | MediaCategory;
-      } | null)
-    | ({
         relationTo: 'users';
         value: string | User;
       } | null)
@@ -1683,6 +1690,10 @@ export interface PayloadLockedDocument {
     | ({
         relationTo: 'brands';
         value: string | Brand;
+      } | null)
+    | ({
+        relationTo: 'payload-folders';
+        value: string | FolderInterface;
       } | null);
   globalSlug?: string | null;
   user:
@@ -1741,9 +1752,9 @@ export interface PayloadMigration {
  * via the `definition` "media_select".
  */
 export interface MediaSelect<T extends boolean = true> {
-  category?: T;
   comment?: T;
   alt?: T;
+  folder?: T;
   updatedAt?: T;
   createdAt?: T;
   url?: T;
@@ -1769,16 +1780,6 @@ export interface MediaSelect<T extends boolean = true> {
               filename?: T;
             };
       };
-}
-/**
- * This interface was referenced by `Config`'s JSON-Schema
- * via the `definition` "mediaCategory_select".
- */
-export interface MediaCategorySelect<T extends boolean = true> {
-  name?: T;
-  media?: T;
-  updatedAt?: T;
-  createdAt?: T;
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema
@@ -2241,6 +2242,18 @@ export interface BrandsSelect<T extends boolean = true> {
 export interface PayloadKvSelect<T extends boolean = true> {
   key?: T;
   data?: T;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "payload-folders_select".
+ */
+export interface PayloadFoldersSelect<T extends boolean = true> {
+  name?: T;
+  folder?: T;
+  documentsAndFolders?: T;
+  folderType?: T;
+  updatedAt?: T;
+  createdAt?: T;
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema

--- a/examples/cms-example/src/payload.config.ts
+++ b/examples/cms-example/src/payload.config.ts
@@ -29,6 +29,9 @@ export default buildConfig({
       deeplApiKey: process.env.DEEPL_API_KEY,
       openaiApiKey: process.env.OPENAI_API_KEY,
       publicMediaBaseUrl: process.env.PUBLIC_MEDIA_BASE_URL,
+      media: {
+        organization: "folders",
+      },
       serverUrl,
       mediaS3Storage: {
         bucket: process.env.MEDIA_S3_BUCKET || "",

--- a/libs/cms-plugin/src/collections/media/config.ts
+++ b/libs/cms-plugin/src/collections/media/config.ts
@@ -1,4 +1,4 @@
-import type { CollectionConfig, Field } from "payload";
+import type { CollectionConfig, CollectionSlug, Field } from "payload";
 
 import { canManageContent } from "../../common/access-control.js";
 import { textareaField } from "../../fields/textarea.js";
@@ -8,6 +8,8 @@ import { generateAltTextEndpoint } from "./generate-alt-text-endpoint.js";
 import { mediaUsagesField } from "./usages.js";
 
 function categoryField({ hidden }: { hidden: boolean }): Field {
+  const relationTo = "mediaCategory" as unknown as CollectionSlug;
+
   return {
     name: "category",
     type: "relationship",
@@ -17,7 +19,7 @@ function categoryField({ hidden }: { hidden: boolean }): Field {
       position: "sidebar",
     },
     label: translated("cmsPlugin:media:category:label"),
-    relationTo: "mediaCategory",
+    relationTo,
   };
 }
 


### PR DESCRIPTION
## Summary
- Configure cms-example to use Payload native media folders via the cmsPlugin media option.
- Regenerate Payload types and admin import map for folder-based media.
- Keep the plugin legacy media category relationship type-safe for folder-only consuming apps.

## Validation
- pnpm --filter cms-example generate:types
- pnpm --filter cms-example generate:importmap
- pnpm --filter cms-example lint
- pnpm --filter cms-example build
- pnpm --filter cms-plugin lint (passes with existing warnings)
- pnpm --filter cms-plugin test:int -- media-organization
- pnpm --filter cms-plugin build
