### PR TITLE
fix(cms-plugin): disable root path translation tools

### DIFF
--- a/libs/cms-plugin/src/collections/brands/root-path.ts
+++ b/libs/cms-plugin/src/collections/brands/root-path.ts
@@ -22,7 +22,6 @@ type TextValidationOptions = ValidateOptions<
 
 export function rootPathField() {
   return textField({
-    enableTranslationTools: false,
     name: "rootPath",
     admin: {
       description: {
@@ -31,6 +30,7 @@ export function rootPathField() {
       },
       placeholder: "e.g. /brand-name",
     },
+    enableTranslationTools: false,
     hooks: {
       beforeValidate: [({ value }) => normalizeRootPathValue(value)],
     },

--- a/libs/cms-plugin/src/collections/brands/root-path.ts
+++ b/libs/cms-plugin/src/collections/brands/root-path.ts
@@ -22,6 +22,7 @@ type TextValidationOptions = ValidateOptions<
 
 export function rootPathField() {
   return textField({
+    enableTranslationTools: false,
     name: "rootPath",
     admin: {
       description: {

--- a/libs/cms-plugin/src/fields/text.ts
+++ b/libs/cms-plugin/src/fields/text.ts
@@ -2,9 +2,9 @@ import type { TextField } from "payload";
 
 import { translated } from "../translations/translations.js";
 
-type TextFieldConfig = Partial<TextField> & {
+type TextFieldConfig = {
   enableTranslationTools?: boolean;
-};
+} & Partial<TextField>;
 
 export function optionalTextField(config: TextFieldConfig = {}): TextField {
   return textField({ ...config, required: false });

--- a/libs/cms-plugin/src/fields/text.ts
+++ b/libs/cms-plugin/src/fields/text.ts
@@ -2,23 +2,31 @@ import type { TextField } from "payload";
 
 import { translated } from "../translations/translations.js";
 
-export function optionalTextField(config: Partial<TextField> = {}): TextField {
+type TextFieldConfig = Partial<TextField> & {
+  enableTranslationTools?: boolean;
+};
+
+export function optionalTextField(config: TextFieldConfig = {}): TextField {
   return textField({ ...config, required: false });
 }
 
-export function textField(config: Partial<TextField> = {}): TextField {
+export function textField(config: TextFieldConfig = {}): TextField {
+  const { enableTranslationTools = true, ...fieldConfig } = config;
+
   return {
     name: "text",
     type: "text",
     label: translated("cmsPlugin:fields:text:label"),
     localized: true,
     required: true,
-    ...config,
+    ...fieldConfig,
     admin: {
-      ...config.admin,
+      ...fieldConfig.admin,
       components: {
-        Label: "@fxmk/cms-plugin/client#TranslationsFieldLabel",
-        ...config.admin?.components,
+        ...(enableTranslationTools
+          ? { Label: "@fxmk/cms-plugin/client#TranslationsFieldLabel" }
+          : {}),
+        ...fieldConfig.admin?.components,
       },
     },
   } as TextField;

--- a/libs/cms-plugin/tests/collections/brands/root-path.test.ts
+++ b/libs/cms-plugin/tests/collections/brands/root-path.test.ts
@@ -42,6 +42,13 @@ async function validateRootPath(
 }
 
 describe("brand root path helpers", () => {
+  it("keeps localization without enabling translation tools", () => {
+    const field = rootPathField();
+
+    expect(field.localized).toBe(true);
+    expect(field.admin?.components?.Label).toBeUndefined();
+  });
+
   it("detects equal root paths as overlapping", () => {
     expect(rootPathsOverlap("/brand", "/brand")).toBe(true);
   });


### PR DESCRIPTION
## Summary

- Add an explicit `enableTranslationTools` option to the shared `textField()` helper.
- Opt the localized brand `rootPath` field out of the translation/auto-translation label UI.
- Add a regression assertion that `rootPath` remains localized without enabling the custom translation label.

## Why

`rootPath` is localized because each locale can have its own URL prefix, but it is still a technical routing field. Showing translation tools for it implies content translation behavior that does not make sense for URL path values.

## Validation

- `pnpm --filter cms-plugin test:int -- tests/collections/brands/root-path.test.ts`
- `pnpm --filter cms-plugin build`
