### PR TITLE
feat(cms-plugin): add brand root path migration

### DIFF
--- a/libs/cms-plugin/README.md
+++ b/libs/cms-plugin/README.md
@@ -15,6 +15,22 @@ localized pathname matches the brand's localized `rootPath`, that page becomes
 the derived home link. New consumers should not treat `homeLink` as the source
 of truth for a brand's URL prefix.
 
+For existing projects that already have production brands with `homeLink` data
+but no `rootPath`, deploy the plugin version that includes `rootPath`, then run
+a Payload migration that calls `migrateBrandHomeLinksToRootPaths` once.
+
+```ts
+import { migrateBrandHomeLinksToRootPaths } from "@fxmk/cms-plugin";
+
+await migrateBrandHomeLinksToRootPaths({
+  payload,
+  req,
+});
+```
+
+Review the returned skipped and missing counts before removing any legacy
+assumptions in your application.
+
 Payload is built with a robust infrastructure intended to support Plugins with
 ease. This provides a simple, modular, and reusable way for developers to extend
 the core capabilities of Payload.

--- a/libs/cms-plugin/src/collections/brands/migrate-home-links-to-root-paths.ts
+++ b/libs/cms-plugin/src/collections/brands/migrate-home-links-to-root-paths.ts
@@ -1,0 +1,263 @@
+import type { Payload, PayloadRequest } from "payload";
+
+import { type LocalizedRootPath, normalizeRootPathValue } from "./root-path.js";
+
+type ID = number | string;
+
+type BrandWithLegacyHomeLink = {
+  homeLink?: {
+    doc?: unknown;
+  };
+  id: ID;
+  rootPath?: unknown;
+};
+
+type PageWithPathname = {
+  id: ID;
+  pathname?: unknown;
+};
+
+type FindResult<T> = {
+  docs: T[];
+};
+
+type PayloadFind = (
+  options: Record<string, unknown>,
+) => Promise<FindResult<unknown>>;
+
+type PayloadFindByID = (options: Record<string, unknown>) => Promise<unknown>;
+
+type PayloadUpdate = (options: Record<string, unknown>) => Promise<unknown>;
+
+type RequestOptions = {
+  req?: PayloadRequest;
+};
+
+export type MigrateBrandHomeLinksToRootPathsOptions = {
+  brandCollectionSlug?: string;
+  dryRun?: boolean;
+  pageCollectionSlug?: string;
+  payload: Payload;
+  req?: PayloadRequest;
+};
+
+export type MigrateBrandHomeLinksToRootPathsResult = {
+  brandsAlreadyMigrated: number;
+  brandsProcessed: number;
+  brandsSkipped: number;
+  brandsUpdated: number;
+  dryRun: boolean;
+  missingHomeLinks: number;
+  missingPages: number;
+};
+
+function relationshipID(value: unknown): ID | undefined {
+  if (typeof value === "number" || typeof value === "string") {
+    return value;
+  }
+
+  if (value && typeof value === "object" && "id" in value) {
+    const id = value.id;
+    if (typeof id === "number" || typeof id === "string") {
+      return id;
+    }
+  }
+
+  return undefined;
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return Boolean(value && typeof value === "object" && !Array.isArray(value));
+}
+
+function usableRootPath(
+  value: unknown,
+): LocalizedRootPath | string | undefined {
+  const normalizedValue = normalizeRootPathValue(value);
+
+  if (typeof normalizedValue === "string" && normalizedValue) {
+    return normalizedValue;
+  }
+
+  if (!isPlainObject(normalizedValue)) {
+    return undefined;
+  }
+
+  const localizedRootPath = Object.fromEntries(
+    Object.entries(normalizedValue).filter(
+      (entry): entry is [string, string] =>
+        typeof entry[1] === "string" && entry[1].length > 0,
+    ),
+  );
+
+  return Object.keys(localizedRootPath).length > 0
+    ? localizedRootPath
+    : undefined;
+}
+
+async function findBrands({
+  brandCollectionSlug,
+  find,
+  requestOptions,
+}: {
+  brandCollectionSlug: string;
+  find: PayloadFind;
+  requestOptions: RequestOptions;
+}) {
+  return (
+    await find({
+      collection: brandCollectionSlug,
+      depth: 0,
+      locale: "all",
+      pagination: false,
+      select: {
+        homeLink: true,
+        rootPath: true,
+      },
+      showHiddenFields: true,
+      ...requestOptions,
+    })
+  ).docs as BrandWithLegacyHomeLink[];
+}
+
+async function findPageByID({
+  findByID,
+  pageCollectionSlug,
+  pageID,
+  requestOptions,
+}: {
+  findByID: PayloadFindByID;
+  pageCollectionSlug: string;
+  pageID: ID;
+  requestOptions: RequestOptions;
+}) {
+  return (await findByID({
+    id: pageID,
+    collection: pageCollectionSlug,
+    depth: 0,
+    disableErrors: true,
+    locale: "all",
+    select: {
+      pathname: true,
+    },
+    ...requestOptions,
+  })) as null | PageWithPathname;
+}
+
+async function updateBrandRootPath({
+  brandCollectionSlug,
+  brandID,
+  requestOptions,
+  rootPath,
+  update,
+}: {
+  brandCollectionSlug: string;
+  brandID: ID;
+  requestOptions: RequestOptions;
+  rootPath: LocalizedRootPath | string;
+  update: PayloadUpdate;
+}) {
+  if (typeof rootPath === "string") {
+    await update({
+      id: brandID,
+      collection: brandCollectionSlug,
+      data: {
+        rootPath,
+      },
+      overrideAccess: true,
+      ...requestOptions,
+    });
+    return;
+  }
+
+  for (const [locale, localizedRootPath] of Object.entries(rootPath)) {
+    await update({
+      id: brandID,
+      collection: brandCollectionSlug,
+      data: {
+        rootPath: localizedRootPath,
+      },
+      locale,
+      overrideAccess: true,
+      ...requestOptions,
+    });
+  }
+}
+
+export async function migrateBrandHomeLinksToRootPaths({
+  brandCollectionSlug = "brands",
+  dryRun = false,
+  pageCollectionSlug = "pages",
+  payload,
+  req,
+}: MigrateBrandHomeLinksToRootPathsOptions): Promise<MigrateBrandHomeLinksToRootPathsResult> {
+  const result: MigrateBrandHomeLinksToRootPathsResult = {
+    brandsAlreadyMigrated: 0,
+    brandsProcessed: 0,
+    brandsSkipped: 0,
+    brandsUpdated: 0,
+    dryRun,
+    missingHomeLinks: 0,
+    missingPages: 0,
+  };
+
+  const requestOptions = req ? { req } : {};
+  const find = payload.find.bind(payload) as unknown as PayloadFind;
+  const findByID = payload.findByID.bind(payload) as unknown as PayloadFindByID;
+  const update = payload.update.bind(payload) as unknown as PayloadUpdate;
+
+  const brands = await findBrands({
+    brandCollectionSlug,
+    find,
+    requestOptions,
+  });
+
+  for (const brand of brands) {
+    result.brandsProcessed += 1;
+
+    if (usableRootPath(brand.rootPath)) {
+      result.brandsAlreadyMigrated += 1;
+      result.brandsSkipped += 1;
+      continue;
+    }
+
+    const homePageID = relationshipID(brand.homeLink?.doc);
+    if (!homePageID) {
+      result.missingHomeLinks += 1;
+      result.brandsSkipped += 1;
+      continue;
+    }
+
+    const page = await findPageByID({
+      findByID,
+      pageCollectionSlug,
+      pageID: homePageID,
+      requestOptions,
+    });
+    if (!page) {
+      result.missingPages += 1;
+      result.brandsSkipped += 1;
+      continue;
+    }
+
+    const rootPath = usableRootPath(page.pathname);
+    if (!rootPath) {
+      result.brandsSkipped += 1;
+      continue;
+    }
+
+    result.brandsUpdated += 1;
+
+    if (!dryRun) {
+      await updateBrandRootPath({
+        brandCollectionSlug,
+        brandID: brand.id,
+        requestOptions,
+        rootPath,
+        update,
+      });
+    }
+  }
+
+  return result;
+}

--- a/libs/cms-plugin/src/collections/brands/migrate-home-links-to-root-paths.ts
+++ b/libs/cms-plugin/src/collections/brands/migrate-home-links-to-root-paths.ts
@@ -1,5 +1,6 @@
 import type { Payload, PayloadRequest } from "payload";
 
+import { validateRootPathFormat } from "../../common/pathname.js";
 import { type LocalizedRootPath, normalizeRootPathValue } from "./root-path.js";
 
 type ID = number | string;
@@ -70,12 +71,19 @@ function isPlainObject(value: unknown): value is Record<string, unknown> {
   return Boolean(value && typeof value === "object" && !Array.isArray(value));
 }
 
+function isUsableRootPath(value: string) {
+  return value.length > 0 && validateRootPathFormat(value) === true;
+}
+
 function usableRootPath(
   value: unknown,
 ): LocalizedRootPath | string | undefined {
   const normalizedValue = normalizeRootPathValue(value);
 
-  if (typeof normalizedValue === "string" && normalizedValue) {
+  if (
+    typeof normalizedValue === "string" &&
+    isUsableRootPath(normalizedValue)
+  ) {
     return normalizedValue;
   }
 
@@ -86,7 +94,7 @@ function usableRootPath(
   const localizedRootPath = Object.fromEntries(
     Object.entries(normalizedValue).filter(
       (entry): entry is [string, string] =>
-        typeof entry[1] === "string" && entry[1].length > 0,
+        typeof entry[1] === "string" && isUsableRootPath(entry[1]),
     ),
   );
 

--- a/libs/cms-plugin/src/index.ts
+++ b/libs/cms-plugin/src/index.ts
@@ -21,6 +21,7 @@ import { Common } from "./globals/common/config.js";
 import { Settings } from "./globals/settings/config.js";
 import { translations } from "./translations/translations.js";
 
+export * from "./collections/brands/migrate-home-links-to-root-paths.js";
 export * from "./collections/media/migrate-categories-to-folders.js";
 export * from "./common/index.js";
 export * from "./fields/index.js";

--- a/libs/cms-plugin/tests/collections/brands/migrate-home-links-to-root-paths.test.ts
+++ b/libs/cms-plugin/tests/collections/brands/migrate-home-links-to-root-paths.test.ts
@@ -138,6 +138,72 @@ describe("migrateBrandHomeLinksToRootPaths", () => {
     expect(payload.update).not.toHaveBeenCalled();
   });
 
+  it("skips malformed scalar pathnames", async () => {
+    const payload = {
+      find: vi.fn(async () => ({
+        docs: [
+          {
+            homeLink: { doc: "page-1" },
+            id: "brand-1",
+          },
+        ],
+      })),
+      findByID: vi.fn(async () => ({
+        id: "page-1",
+        pathname: "brand",
+      })),
+      update: vi.fn(),
+    } as unknown as Payload;
+
+    const result = await migrateBrandHomeLinksToRootPaths({ payload });
+
+    expect(result).toMatchObject({
+      brandsProcessed: 1,
+      brandsSkipped: 1,
+      brandsUpdated: 0,
+    });
+    expect(payload.update).not.toHaveBeenCalled();
+  });
+
+  it("filters malformed localized pathnames before updating brands", async () => {
+    const payload = {
+      find: vi.fn(async () => ({
+        docs: [
+          {
+            homeLink: { doc: "page-1" },
+            id: "brand-1",
+          },
+        ],
+      })),
+      findByID: vi.fn(async () => ({
+        id: "page-1",
+        pathname: {
+          en: "/brand",
+          es: "/marca/",
+        },
+      })),
+      update: vi.fn(async () => ({})),
+    } as unknown as Payload;
+
+    const result = await migrateBrandHomeLinksToRootPaths({ payload });
+
+    expect(result).toMatchObject({
+      brandsProcessed: 1,
+      brandsSkipped: 0,
+      brandsUpdated: 1,
+    });
+    expect(payload.update).toHaveBeenCalledOnce();
+    expect(payload.update).toHaveBeenCalledWith({
+      collection: "brands",
+      data: {
+        rootPath: "/brand",
+      },
+      id: "brand-1",
+      locale: "en",
+      overrideAccess: true,
+    });
+  });
+
   it("reports missing home links without throwing", async () => {
     const payload = {
       find: vi.fn(async () => ({

--- a/libs/cms-plugin/tests/collections/brands/migrate-home-links-to-root-paths.test.ts
+++ b/libs/cms-plugin/tests/collections/brands/migrate-home-links-to-root-paths.test.ts
@@ -1,0 +1,186 @@
+import type { Payload } from "payload";
+
+import { describe, expect, it, vi } from "vitest";
+
+import { migrateBrandHomeLinksToRootPaths } from "../../../src/collections/brands/migrate-home-links-to-root-paths.js";
+
+describe("migrateBrandHomeLinksToRootPaths", () => {
+  it("migrates legacy home links to localized root paths", async () => {
+    const payload = {
+      find: vi.fn(async () => ({
+        docs: [
+          {
+            homeLink: { doc: "page-1" },
+            id: "brand-1",
+          },
+        ],
+      })),
+      findByID: vi.fn(async () => ({
+        id: "page-1",
+        pathname: {
+          en: " /brand ",
+          es: " /marca ",
+        },
+      })),
+      update: vi.fn(async () => ({})),
+    } as unknown as Payload;
+
+    const result = await migrateBrandHomeLinksToRootPaths({ payload });
+
+    expect(result).toEqual({
+      brandsAlreadyMigrated: 0,
+      brandsProcessed: 1,
+      brandsSkipped: 0,
+      brandsUpdated: 1,
+      dryRun: false,
+      missingHomeLinks: 0,
+      missingPages: 0,
+    });
+    expect(payload.find).toHaveBeenCalledWith({
+      collection: "brands",
+      depth: 0,
+      locale: "all",
+      pagination: false,
+      select: {
+        homeLink: true,
+        rootPath: true,
+      },
+      showHiddenFields: true,
+    });
+    expect(payload.findByID).toHaveBeenCalledWith({
+      collection: "pages",
+      depth: 0,
+      disableErrors: true,
+      id: "page-1",
+      locale: "all",
+      select: {
+        pathname: true,
+      },
+    });
+    expect(payload.update).toHaveBeenCalledTimes(2);
+    expect(payload.update).toHaveBeenNthCalledWith(1, {
+      collection: "brands",
+      data: {
+        rootPath: "/brand",
+      },
+      id: "brand-1",
+      locale: "en",
+      overrideAccess: true,
+    });
+    expect(payload.update).toHaveBeenNthCalledWith(2, {
+      collection: "brands",
+      data: {
+        rootPath: "/marca",
+      },
+      id: "brand-1",
+      locale: "es",
+      overrideAccess: true,
+    });
+  });
+
+  it("skips brands that already have root paths", async () => {
+    const payload = {
+      find: vi.fn(async () => ({
+        docs: [
+          {
+            homeLink: { doc: "page-1" },
+            id: "brand-1",
+            rootPath: {
+              en: "/brand",
+            },
+          },
+        ],
+      })),
+      findByID: vi.fn(),
+      update: vi.fn(),
+    } as unknown as Payload;
+
+    const result = await migrateBrandHomeLinksToRootPaths({ payload });
+
+    expect(result).toMatchObject({
+      brandsAlreadyMigrated: 1,
+      brandsProcessed: 1,
+      brandsSkipped: 1,
+      brandsUpdated: 0,
+    });
+    expect(payload.findByID).not.toHaveBeenCalled();
+    expect(payload.update).not.toHaveBeenCalled();
+  });
+
+  it("supports dry runs without updating brands", async () => {
+    const payload = {
+      find: vi.fn(async () => ({
+        docs: [
+          {
+            homeLink: { doc: { id: "page-1" } },
+            id: "brand-1",
+          },
+        ],
+      })),
+      findByID: vi.fn(async () => ({
+        id: "page-1",
+        pathname: "/brand",
+      })),
+      update: vi.fn(),
+    } as unknown as Payload;
+
+    const result = await migrateBrandHomeLinksToRootPaths({
+      dryRun: true,
+      payload,
+    });
+
+    expect(result).toMatchObject({
+      brandsProcessed: 1,
+      brandsSkipped: 0,
+      brandsUpdated: 1,
+      dryRun: true,
+    });
+    expect(payload.update).not.toHaveBeenCalled();
+  });
+
+  it("reports missing home links without throwing", async () => {
+    const payload = {
+      find: vi.fn(async () => ({
+        docs: [{ id: "brand-1" }],
+      })),
+      findByID: vi.fn(),
+      update: vi.fn(),
+    } as unknown as Payload;
+
+    const result = await migrateBrandHomeLinksToRootPaths({ payload });
+
+    expect(result).toMatchObject({
+      brandsProcessed: 1,
+      brandsSkipped: 1,
+      brandsUpdated: 0,
+      missingHomeLinks: 1,
+    });
+    expect(payload.findByID).not.toHaveBeenCalled();
+    expect(payload.update).not.toHaveBeenCalled();
+  });
+
+  it("reports missing linked pages without throwing", async () => {
+    const payload = {
+      find: vi.fn(async () => ({
+        docs: [
+          {
+            homeLink: { doc: "missing-page" },
+            id: "brand-1",
+          },
+        ],
+      })),
+      findByID: vi.fn(async () => null),
+      update: vi.fn(),
+    } as unknown as Payload;
+
+    const result = await migrateBrandHomeLinksToRootPaths({ payload });
+
+    expect(result).toMatchObject({
+      brandsProcessed: 1,
+      brandsSkipped: 1,
+      brandsUpdated: 0,
+      missingPages: 1,
+    });
+    expect(payload.update).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Context
`rootPath` is now the source of truth for brand URL namespaces, but existing cms-plugin consumers can have production brand records that only contain the legacy hidden `homeLink` relationship. Those records need a deterministic one-time migration path before consumers remove legacy assumptions.

## Summary
- add an exported `migrateBrandHomeLinksToRootPaths` helper for cms-plugin consumers
- derive missing brand `rootPath` values from legacy `homeLink` page pathnames
- normalize and validate migration candidates before writing so malformed paths are skipped instead of crashing the migration
- document the migration flow and add focused Vitest coverage

## Risk and Mitigation
- Migration risk is constrained by `dryRun`, explicit result counters, and skip behavior for missing or invalid source data.
- Localized `rootPath` values are written per locale to match Payload's collection update API.
- The helper is opt-in and exported for consumer-owned Payload migrations; it does not add startup side effects to the plugin.

## Known Limitations
- Records without a usable `homeLink.doc`, missing linked page, or valid pathname are skipped and must be reviewed manually from the returned counts.
- The helper does not invent fallback root paths such as `/`.

## Checks
- `pnpm --filter cms-plugin test:int`
- `pnpm --filter cms-plugin build`
- `pnpm check`