### PR TITLE
fix(cms-plugin): allow nested brand root paths

### DIFF
--- a/libs/cms-plugin/README.md
+++ b/libs/cms-plugin/README.md
@@ -7,7 +7,9 @@ A template repo to create a [Payload CMS](https://payloadcms.com) plugin.
 Brands own their URL namespace through the localized `rootPath` field. Use
 `rootPath` as the preferred public API for brand routing and URL-prefix logic.
 Every page assigned to a brand must use either the brand's root path itself or a
-child path below it.
+child path below it. Nested root paths are valid: for example, one default brand
+can own `/` while more specific brands own `/aqua` and `/azul`. When multiple
+brand root paths match a URL, the most specific root path wins.
 
 The `homeLink` field is kept for backwards compatibility with existing API
 consumers. It is hidden from editors and managed by the plugin: when a page's

--- a/libs/cms-plugin/src/collections/brands/root-path.ts
+++ b/libs/cms-plugin/src/collections/brands/root-path.ts
@@ -97,11 +97,11 @@ async function validateRootPathValue(
     return t(`cmsPlugin:brands:rootPath:${formatValidationResult}`);
   }
 
-  const overlappingBrand = (
-    await getBrandsWithOverlappingRootPath(options.req, rootPath)
+  const duplicateBrand = (
+    await getBrandsWithDuplicateRootPath(options.req, rootPath)
   ).find((brand) => brand.id !== options.id);
-  if (overlappingBrand) {
-    return t("cmsPlugin:brands:rootPath:overlaps");
+  if (duplicateBrand) {
+    return t("cmsPlugin:brands:rootPath:alreadyExists");
   }
 
   return true;
@@ -145,7 +145,7 @@ export function resolveRootPathForLocale(
     : undefined;
 }
 
-export async function getBrandsWithOverlappingRootPath(
+export async function getBrandsWithDuplicateRootPath(
   req: PayloadRequest,
   rootPath: string,
 ) {
@@ -163,15 +163,61 @@ export async function getBrandsWithOverlappingRootPath(
 
   return result.docs.filter((brand) =>
     getLocalizedRootPaths(brand.rootPath, publishedLocaleIds).some(
-      (existingRootPath) => rootPathsOverlap(existingRootPath, rootPath),
+      (existingRootPath) => rootPathsAreEqual(existingRootPath, rootPath),
     ),
   );
 }
 
-export function rootPathsOverlap(rootPathA: string, rootPathB: string) {
+export function rootPathsAreEqual(rootPathA: string, rootPathB: string) {
   return (
-    pathnameBelongsToRootPath(rootPathA, rootPathB) ||
-    pathnameBelongsToRootPath(rootPathB, rootPathA)
+    normalizePathnameInput(rootPathA) === normalizePathnameInput(rootPathB)
+  );
+}
+
+export async function getMostSpecificBrandForPathname({
+  localeId,
+  pathname,
+  req,
+}: {
+  localeId: string | undefined;
+  pathname: string;
+  req: PayloadRequest;
+}) {
+  if (!localeId) {
+    return undefined;
+  }
+
+  const result = await req.payload.find({
+    collection: "brands",
+    locale: "all",
+    pagination: false,
+    req: createIsolatedLocalRequest(req),
+    select: {
+      rootPath: true,
+    },
+  });
+
+  return result.docs.reduce<{ id: unknown; rootPath: string } | undefined>(
+    (mostSpecificBrand, brand) => {
+      const rootPath = resolveRootPathForLocale(brand.rootPath, localeId);
+
+      if (!rootPath || !pathnameBelongsToRootPath(pathname, rootPath)) {
+        return mostSpecificBrand;
+      }
+
+      if (
+        !mostSpecificBrand ||
+        rootPath.length > mostSpecificBrand.rootPath.length
+      ) {
+        return {
+          id: brand.id,
+          rootPath,
+        };
+      }
+
+      return mostSpecificBrand;
+    },
+    undefined,
   );
 }
 

--- a/libs/cms-plugin/src/collections/pages/config.ts
+++ b/libs/cms-plugin/src/collections/pages/config.ts
@@ -23,7 +23,10 @@ import { textField } from "../../fields/text.js";
 import { textareaField } from "../../fields/textarea.js";
 import { contentGroup } from "../../groups.js";
 import { getPageBrandId, syncBrandHomeLink } from "../brands/home-link.js";
-import { resolveRootPathForLocale } from "../brands/root-path.js";
+import {
+  getMostSpecificBrandForPathname,
+  resolveRootPathForLocale,
+} from "../brands/root-path.js";
 import {
   getLocalizedPathnameEndpoint,
   getPagesForPathname,
@@ -250,7 +253,11 @@ export function Pages({
           const { id, req, siblingData } = options;
           const t = req.t as unknown as TFunction<TranslationsKey>;
 
-          if (!siblingData.brand) {
+          const brandId = getPageBrandId({
+            brand: siblingData.brand,
+          });
+
+          if (!brandId) {
             return t("cmsPlugin:pages:pathname:pleaseSelectABrandFirst");
           }
 
@@ -259,7 +266,7 @@ export function Pages({
           }
 
           const brand = await req.payload.findByID({
-            id: siblingData.brand as string,
+            id: brandId,
             collection: "brands",
             depth: 2,
             req,
@@ -291,6 +298,24 @@ export function Pages({
               return t("cmsPlugin:pages:pathname:pathnameMustStartWithPrefix", {
                 prefix: rootPath,
               });
+            }
+
+            const mostSpecificBrand = await getMostSpecificBrandForPathname({
+              localeId: locale,
+              pathname: value,
+              req,
+            });
+
+            if (
+              mostSpecificBrand &&
+              String(mostSpecificBrand.id) !== String(brandId)
+            ) {
+              return t(
+                "cmsPlugin:pages:pathname:pathnameBelongsToMoreSpecificBrand",
+                {
+                  prefix: mostSpecificBrand.rootPath,
+                },
+              );
             }
           }
 

--- a/libs/cms-plugin/src/translations/locales/en.ts
+++ b/libs/cms-plugin/src/translations/locales/en.ts
@@ -203,6 +203,8 @@ export const en = {
         createRedirect:
           "Create a redirect from '{{ previousPathname }}' to this page.",
         lock: "Lock",
+        pathnameBelongsToMoreSpecificBrand:
+          "The pathname belongs to the more specific brand root path '{{ prefix }}'.",
         pathnameMustStartWithPrefix:
           "The pathname must start with '{{ prefix }}'.",
         pleaseEnterAPathname: "Please enter a pathname.",

--- a/libs/cms-plugin/src/translations/locales/es.ts
+++ b/libs/cms-plugin/src/translations/locales/es.ts
@@ -206,6 +206,8 @@ export const es: TranslationsObject = {
         createRedirect:
           "Crear una redirección para esta ruta a la página seleccionada",
         lock: "Bloquear",
+        pathnameBelongsToMoreSpecificBrand:
+          "La ruta pertenece a la ruta raíz de marca más específica '{{ prefix }}'.",
         pathnameMustStartWithPrefix: `La ruta debe comenzar con '{{ prefix }}'.`,
         pleaseEnterAPathname: "Por favor, ingrese una ruta.",
         pleaseSelectABrandFirst: "Por favor, seleccione una marca primero.",

--- a/libs/cms-plugin/tests/collections/brands/migrate-home-links-to-root-paths.test.ts
+++ b/libs/cms-plugin/tests/collections/brands/migrate-home-links-to-root-paths.test.ts
@@ -78,6 +78,64 @@ describe("migrateBrandHomeLinksToRootPaths", () => {
     });
   });
 
+  it("updates nested brand root paths through Payload validation", async () => {
+    const payload = {
+      find: vi.fn(async () => ({
+        docs: [
+          {
+            homeLink: { doc: "puerta-home" },
+            id: "puerta",
+          },
+          {
+            homeLink: { doc: "aqua-home" },
+            id: "aqua",
+          },
+        ],
+      })),
+      findByID: vi.fn(async ({ id }: { id: string }) => ({
+        id,
+        pathname:
+          id === "puerta-home"
+            ? {
+                en: "/",
+                es: "/",
+              }
+            : {
+                en: "/aqua",
+                es: "/aqua",
+              },
+      })),
+      update: vi.fn(async () => ({})),
+    } as unknown as Payload;
+
+    const result = await migrateBrandHomeLinksToRootPaths({ payload });
+
+    expect(result).toMatchObject({
+      brandsProcessed: 2,
+      brandsSkipped: 0,
+      brandsUpdated: 2,
+    });
+    expect(payload.update).toHaveBeenCalledTimes(4);
+    expect(payload.update).toHaveBeenCalledWith({
+      collection: "brands",
+      data: {
+        rootPath: "/",
+      },
+      id: "puerta",
+      locale: "en",
+      overrideAccess: true,
+    });
+    expect(payload.update).toHaveBeenCalledWith({
+      collection: "brands",
+      data: {
+        rootPath: "/aqua",
+      },
+      id: "aqua",
+      locale: "en",
+      overrideAccess: true,
+    });
+  });
+
   it("skips brands that already have root paths", async () => {
     const payload = {
       find: vi.fn(async () => ({

--- a/libs/cms-plugin/tests/collections/brands/root-path.test.ts
+++ b/libs/cms-plugin/tests/collections/brands/root-path.test.ts
@@ -3,11 +3,12 @@ import type { PayloadRequest } from "payload";
 import { describe, expect, it } from "vitest";
 
 import {
-  getBrandsWithOverlappingRootPath,
+  getBrandsWithDuplicateRootPath,
+  getMostSpecificBrandForPathname,
   normalizeRootPathValue,
   resolveRootPathForLocale,
   rootPathField,
-  rootPathsOverlap,
+  rootPathsAreEqual,
 } from "../../../src/collections/brands/root-path.js";
 
 function createValidateOptions({
@@ -52,21 +53,21 @@ describe("brand root path helpers", () => {
     expect(field.admin?.components?.Label).toBeUndefined();
   });
 
-  it("detects equal root paths as overlapping", () => {
-    expect(rootPathsOverlap("/brand", "/brand")).toBe(true);
+  it("detects equal root paths as duplicates", () => {
+    expect(rootPathsAreEqual("/brand", "/brand")).toBe(true);
   });
 
-  it("detects parent and child root paths as overlapping", () => {
-    expect(rootPathsOverlap("/brand", "/brand/sub")).toBe(true);
-    expect(rootPathsOverlap("/brand/sub", "/brand")).toBe(true);
+  it("allows parent and child root paths", () => {
+    expect(rootPathsAreEqual("/brand", "/brand/sub")).toBe(false);
+    expect(rootPathsAreEqual("/brand/sub", "/brand")).toBe(false);
   });
 
-  it("treats the site root as overlapping every child path", () => {
-    expect(rootPathsOverlap("/", "/brand")).toBe(true);
+  it("allows the site root with child paths", () => {
+    expect(rootPathsAreEqual("/", "/brand")).toBe(false);
   });
 
-  it("does not treat sibling path prefixes as overlapping", () => {
-    expect(rootPathsOverlap("/brand", "/brandish")).toBe(false);
+  it("does not treat sibling path prefixes as duplicates", () => {
+    expect(rootPathsAreEqual("/brand", "/brandish")).toBe(false);
   });
 
   it("normalizes active-locale root path strings", () => {
@@ -119,6 +120,69 @@ describe("brand root path helpers", () => {
     ).resolves.toBe("cmsPlugin:brands:rootPath:mustStartWithSlash");
   });
 
+  it("rejects exact duplicate root paths from another brand", async () => {
+    await expect(
+      validateRootPath(
+        {
+          en: "/brand",
+          es: "/marca",
+        },
+        createValidateOptions({
+          docs: [
+            {
+              id: "other-brand",
+              rootPath: {
+                en: "/brand",
+              },
+            },
+          ],
+        }),
+      ),
+    ).resolves.toBe("cmsPlugin:brands:rootPath:alreadyExists");
+  });
+
+  it("allows nested root paths from another brand", async () => {
+    await expect(
+      validateRootPath(
+        {
+          en: "/",
+          es: "/",
+        },
+        createValidateOptions({
+          docs: [
+            {
+              id: "aqua",
+              rootPath: {
+                en: "/aqua",
+                es: "/aqua",
+              },
+            },
+          ],
+        }),
+      ),
+    ).resolves.toBe(true);
+
+    await expect(
+      validateRootPath(
+        {
+          en: "/brand/sub",
+          es: "/marca/sub",
+        },
+        createValidateOptions({
+          docs: [
+            {
+              id: "parent-brand",
+              rootPath: {
+                en: "/brand",
+                es: "/marca",
+              },
+            },
+          ],
+        }),
+      ),
+    ).resolves.toBe(true);
+  });
+
   it("rejects malformed localized root path objects", async () => {
     await expect(
       validateRootPath({
@@ -157,7 +221,7 @@ describe("brand root path helpers", () => {
       },
     } as unknown as PayloadRequest;
 
-    await getBrandsWithOverlappingRootPath(req, "/new");
+    await getBrandsWithDuplicateRootPath(req, "/new");
 
     expect(localAPIReq).toBeDefined();
     if (!localAPIReq) {
@@ -168,5 +232,67 @@ describe("brand root path helpers", () => {
     expect(Object.getPrototypeOf(localAPIReq)).toBe(req);
     expect(localAPIReq.locale).toBe("all");
     expect(req.locale).toBe("en");
+  });
+
+  it("finds the most specific brand for a nested pathname", async () => {
+    const req = {
+      payload: {
+        find: async () => ({
+          docs: [
+            {
+              id: "root",
+              rootPath: {
+                en: "/",
+              },
+            },
+            {
+              id: "aqua",
+              rootPath: {
+                en: "/aqua",
+              },
+            },
+            {
+              id: "azul",
+              rootPath: {
+                en: "/azul",
+              },
+            },
+          ],
+        }),
+      },
+    } as unknown as PayloadRequest;
+
+    await expect(
+      getMostSpecificBrandForPathname({
+        localeId: "en",
+        pathname: "/aqua/page",
+        req,
+      }),
+    ).resolves.toEqual({
+      id: "aqua",
+      rootPath: "/aqua",
+    });
+
+    await expect(
+      getMostSpecificBrandForPathname({
+        localeId: "en",
+        pathname: "/azul",
+        req,
+      }),
+    ).resolves.toEqual({
+      id: "azul",
+      rootPath: "/azul",
+    });
+
+    await expect(
+      getMostSpecificBrandForPathname({
+        localeId: "en",
+        pathname: "/aquaish",
+        req,
+      }),
+    ).resolves.toEqual({
+      id: "root",
+      rootPath: "/",
+    });
   });
 });

--- a/libs/cms-plugin/tests/collections/pages/config.test.ts
+++ b/libs/cms-plugin/tests/collections/pages/config.test.ts
@@ -1,0 +1,61 @@
+import type { PayloadRequest, TextField } from "payload";
+
+import { describe, expect, it } from "vitest";
+
+import { Pages } from "../../../src/collections/pages/config.js";
+
+function pathnameField() {
+  return Pages({}).fields.find(
+    (field): field is TextField => "name" in field && field.name === "pathname",
+  )!;
+}
+
+describe("page pathname validation", () => {
+  it("rejects pages assigned to a less specific brand root", async () => {
+    const req = {
+      payload: {
+        config: {
+          localization: {
+            defaultLocale: "en",
+          },
+        },
+        find: async () => ({
+          docs: [
+            {
+              id: "root",
+              rootPath: {
+                en: "/",
+              },
+            },
+            {
+              id: "aqua",
+              rootPath: {
+                en: "/aqua",
+              },
+            },
+          ],
+        }),
+        findByID: async () => ({
+          rootPath: {
+            en: "/",
+          },
+        }),
+      },
+      t: (key: string, params?: Record<string, string>) =>
+        params?.prefix ? `${key}:${params.prefix}` : key,
+    } as unknown as PayloadRequest;
+
+    await expect(
+      pathnameField().validate!("/aqua/about", {
+        id: "page",
+        req,
+        required: true,
+        siblingData: {
+          brand: "root",
+        },
+      } as never),
+    ).resolves.toBe(
+      "cmsPlugin:pages:pathname:pathnameBelongsToMoreSpecificBrand:/aqua",
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- allow nested brand root paths while continuing to reject exact duplicates
- enforce most-specific brand root ownership during page pathname validation
- add regression coverage for nested root paths and the existing brand root-path migration helper

## Verification
- pnpm format:check
- pnpm --filter cms-plugin test:int
- pnpm --filter cms-plugin lint (passes with existing warnings)
- pnpm --filter cms-plugin build

## Risks and mitigations
- Nested route ownership changes page validation semantics; regression tests cover `/`, `/aqua`, sibling prefixes, and less-specific brand assignment.
- The migration helper remains the existing exported API; this PR only verifies it can run through normal Payload validation for nested root setups.