### PR TITLE
perf(cms-example): speed up Docker CI builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -122,6 +122,11 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v6
+      - name: Get cms-example package version
+        id: package-version
+        run: |
+          PACKAGE_VERSION=$(node -p "require('./examples/cms-example/package.json').version")
+          echo "version=$PACKAGE_VERSION" >> "$GITHUB_OUTPUT"
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
       - name: Build cms-example Docker image
@@ -130,6 +135,8 @@ jobs:
           context: .
           file: examples/cms-example/Dockerfile
           push: false
+          build-args: |
+            APP_VERSION=${{ steps.package-version.outputs.version }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -91,10 +91,6 @@ jobs:
           version: ${{ env.FLYCTL_VERSION }}
       - name: Setup
         uses: ./.github/actions/setup
-      - name: Set version on cms-example
-        run: |
-          pnpm version ${{ needs.version.outputs.version }} --git-tag-version false
-        working-directory: examples/cms-example
       - name: Get cms-example image name
         id: image-name
         run: |
@@ -109,6 +105,7 @@ jobs:
             --app ${{ steps.image-name.outputs.image_name }} \
             --config examples/cms-example/fly.build.toml \
             --build-only \
+            --build-arg APP_VERSION=${{ needs.version.outputs.version }} \
             --image-label ${{ steps.image-name.outputs.image_tag }} \
             --label org.opencontainers.image.version=${{ steps.image-name.outputs.image_tag }} \
             --push
@@ -125,8 +122,16 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v6
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
       - name: Build cms-example Docker image
-        run: docker build -f examples/cms-example/Dockerfile .
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          file: examples/cms-example/Dockerfile
+          push: false
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
 
   cms-example-image-ready:
     name: "cms-example: Image Ready"

--- a/examples/cms-example/Dockerfile
+++ b/examples/cms-example/Dockerfile
@@ -1,3 +1,4 @@
+# syntax=docker/dockerfile:1.7
 # From https://github.com/vercel/next.js/blob/canary/examples/with-docker/Dockerfile
 
 FROM node:24-alpine AS base
@@ -9,18 +10,30 @@ FROM base AS builder
 RUN apk add --no-cache libc6-compat
 WORKDIR /app
 ENV CI=true
+ARG APP_VERSION=0.0.0-unknown
 
 RUN corepack enable pnpm
 
 COPY --link package.json pnpm-lock.yaml pnpm-workspace.yaml .npmrc ./
+COPY --link examples/cms-example/package.json examples/cms-example/package.json
+COPY --link libs/cms-plugin/package.json libs/cms-plugin/package.json
+COPY --link libs/common/package.json libs/common/package.json
+
+RUN --mount=type=cache,id=pnpm-store,target=/root/.local/share/pnpm/store \
+      pnpm fetch --frozen-lockfile
+
 COPY --link examples/cms-example examples/cms-example
 COPY --link libs/cms-plugin libs/cms-plugin
 COPY --link libs/common libs/common
 
-RUN pnpm --filter cms-example --filter cms-plugin --filter common install --frozen-lockfile
+RUN --mount=type=cache,id=pnpm-store,target=/root/.local/share/pnpm/store \
+      pnpm --filter cms-example --filter cms-plugin --filter common install --frozen-lockfile --offline
+RUN pnpm --filter cms-example exec pnpm version "$APP_VERSION" --git-tag-version false
 RUN pnpm --filter common build
 RUN pnpm --filter cms-plugin build
-RUN pnpm --filter cms-example build
+RUN --mount=type=cache,id=next-cache,target=/app/examples/cms-example/.next/cache \
+      pnpm --filter cms-example build
+RUN mkdir -p examples/cms-example/public
 
 FROM base AS runner
 WORKDIR /app
@@ -30,14 +43,9 @@ ENV NODE_ENV=production
 RUN addgroup --system --gid 1001 nodejs
 RUN adduser --system --uid 1001 nextjs
 
-COPY --from=builder /app .
-
-RUN mkdir -p examples/cms-example/.next/standalone/examples/cms-example/.next
-RUN mv examples/cms-example/.next/static examples/cms-example/.next/standalone/examples/cms-example/.next/static
-RUN if [ -d examples/cms-example/public ]; then \
-      cp -r examples/cms-example/public examples/cms-example/.next/standalone/examples/cms-example/public; \
-    fi
-RUN chown -R nextjs:nodejs examples/cms-example/.next/standalone/examples/cms-example/.next
+COPY --from=builder --chown=nextjs:nodejs /app/examples/cms-example/.next/standalone ./
+COPY --from=builder --chown=nextjs:nodejs /app/examples/cms-example/.next/static ./examples/cms-example/.next/static
+COPY --from=builder --chown=nextjs:nodejs /app/examples/cms-example/public ./examples/cms-example/public
 
 USER nextjs
 

--- a/examples/cms-example/Dockerfile
+++ b/examples/cms-example/Dockerfile
@@ -59,4 +59,4 @@ EXPOSE 3000
 
 ENV PORT=3000
 
-CMD HOSTNAME="0.0.0.0" node examples/cms-example/.next/standalone/examples/cms-example/server.js
+CMD HOSTNAME="0.0.0.0" node examples/cms-example/server.js

--- a/examples/cms-example/Dockerfile
+++ b/examples/cms-example/Dockerfile
@@ -28,11 +28,17 @@ COPY --link libs/common libs/common
 
 RUN --mount=type=cache,id=pnpm-store,target=/root/.local/share/pnpm/store \
       pnpm --filter cms-example --filter cms-plugin --filter common install --frozen-lockfile --offline
-RUN pnpm --filter cms-example exec pnpm version "$APP_VERSION" --git-tag-version false
 RUN pnpm --filter common build
 RUN pnpm --filter cms-plugin build
 RUN --mount=type=cache,id=next-cache,target=/app/examples/cms-example/.next/cache \
       pnpm --filter cms-example build
+RUN node -e ' \
+      const fs = require("node:fs"); \
+      const packagePath = "examples/cms-example/.next/standalone/examples/cms-example/package.json"; \
+      const packageJson = JSON.parse(fs.readFileSync(packagePath, "utf8")); \
+      packageJson.version = process.env.APP_VERSION; \
+      fs.writeFileSync(packagePath, `${JSON.stringify(packageJson, null, 2)}\n`); \
+    '
 RUN mkdir -p examples/cms-example/public
 
 FROM base AS runner


### PR DESCRIPTION
## Problem / Context
The cms-example Docker image build was slow because dependency installation and package builds were easy to invalidate, and the runtime stage copied the whole builder filesystem instead of only the Next standalone output.

## What Changed
- Reordered the Dockerfile so root/workspace manifests are copied before source, then `pnpm fetch --frozen-lockfile` can be cached before source changes invalidate later layers.
- Added BuildKit cache mounts for the pnpm store and the Next build cache.
- Moved cms-example version injection into the Docker build via `APP_VERSION`, and now apply it only to the standalone runtime package metadata after the app build.
- Kept `common`, `cms-plugin`, and `cms-example` builds hermetic inside Docker while preserving their cacheability across version-only changes.
- Slimmed the runtime stage to copy only the Next standalone output, static assets, and public assets.
- Switched the fallback fork/Dependabot image build job to Docker Buildx with GitHub Actions cache and an explicit `APP_VERSION` build arg.

## Validation
- `pnpm --filter common build`
- `pnpm --filter cms-plugin build`
- `pnpm --filter cms-example build`
- `pnpm format:check`
- `git diff --check`
- GitHub Actions on PR #55: `Quality Gates`, `common: Build`, `cms-plugin: Build`, and `cms-example: Build and Push` passed.
- Verified `docker/build-push-action@v7` and `docker/setup-buildx-action@v4` tags exist.

## Risks / Mitigations
- Local Docker daemon was unavailable in this environment, so local `docker build --progress=plain -f examples/cms-example/Dockerfile .` could not be run. Mitigation: the PR's Fly/Depot `cms-example: Build and Push` check passed.
- The fork/Dependabot fallback image job is skipped for this internal PR. Mitigation: action tags were verified and the workflow passes `APP_VERSION` explicitly.

## Follow-ups / Known Limitations
- Docker cache effectiveness should be observed over a few Fly/Depot builds, since the exact win depends on remote builder cache retention.