### PR TITLE
feat(cms-plugin): decouple brand theme color

### DIFF
--- a/examples/cms-example/src/payload-types.ts
+++ b/examples/cms-example/src/payload-types.ts
@@ -1050,7 +1050,7 @@ export interface Page {
     image?: (string | null) | Media;
   };
   /**
-   * Choose the brand to which the page belongs. The brand determines the theme of the page.
+   * Choose the brand to which the page belongs. The page pathname must live within the brand's root path.
    */
   brand: string | Brand;
   /**
@@ -1581,6 +1581,10 @@ export interface Brand {
    * The localized root path for this brand. Pages for this brand must use this path or a child path below it.
    */
   rootPath: string;
+  /**
+   * Choose the theme color used by the frontend for this brand.
+   */
+  themeColor: 'default' | 'aqua' | 'azul';
   /**
    * The base title is appended to the titles of the brand’s pages. If the page does not have a title, the base title will be used as the title. Include important keywords in the title for SEO.
    */
@@ -2198,6 +2202,7 @@ export interface BrandsSelect<T extends boolean = true> {
   name?: T;
   homeLink?: T | NewLinkSelect<T>;
   rootPath?: T;
+  themeColor?: T;
   baseTitle?: T;
   logo?: T;
   banner?: T;

--- a/examples/cms-example/src/payload.config.ts
+++ b/examples/cms-example/src/payload.config.ts
@@ -32,6 +32,11 @@ export default buildConfig({
       media: {
         organization: "folders",
       },
+      themeColors: [
+        { label: "Default", value: "default" },
+        { label: "Aqua", value: "aqua" },
+        { label: "Azul", value: "azul" },
+      ],
       serverUrl,
       mediaS3Storage: {
         bucket: process.env.MEDIA_S3_BUCKET || "",

--- a/libs/cms-plugin/README.md
+++ b/libs/cms-plugin/README.md
@@ -33,6 +33,53 @@ await migrateBrandHomeLinksToRootPaths({
 Review the returned skipped and missing counts before removing any legacy
 assumptions in your application.
 
+## Brand Theme Color Model
+
+Brands expose an explicit `themeColor` field so editors can choose a visual
+theme independently from the brand identity. Configure the available theme
+tokens in `cmsPlugin`; the first option is used as the default for newly created
+brands.
+
+```ts
+cmsPlugin({
+  themeColors: [
+    { label: "Puerta", value: "puerta" },
+    { label: "Aqua", value: "aqua" },
+    { label: "Azul", value: "azul" },
+  ],
+  mediaS3Storage: {
+    accessKeyId: process.env.MEDIA_S3_ACCESS_KEY_ID || "",
+    bucket: process.env.MEDIA_S3_BUCKET || "",
+    region: process.env.MEDIA_S3_REGION || "",
+    secretAccessKey: process.env.MEDIA_S3_SECRET_ACCESS_KEY || "",
+  },
+});
+```
+
+Existing brand documents created before `themeColor` existed need to be
+backfilled before frontends switch from brand-id-based theme lookup to
+`brand.themeColor`. Run a Payload migration that maps existing brand IDs to the
+desired theme token.
+
+```ts
+import { migrateBrandThemeColors } from "@fxmk/cms-plugin";
+
+await migrateBrandThemeColors({
+  payload,
+  req,
+  defaultThemeColor: "puerta",
+  themeColorByBrandId: {
+    puerta: "puerta",
+    aqua: "aqua",
+    azul: "azul",
+  },
+});
+```
+
+Review `brandsUsingDefaultThemeColor` in the returned result. A non-zero value
+can be expected for intentional default-brand fallbacks, but it is also a useful
+signal that a newly discovered brand ID was not included in the mapping.
+
 Payload is built with a robust infrastructure intended to support Plugins with
 ease. This provides a simple, modular, and reusable way for developers to extend
 the core capabilities of Payload.

--- a/libs/cms-plugin/src/collections/brands/config.ts
+++ b/libs/cms-plugin/src/collections/brands/config.ts
@@ -17,13 +17,28 @@ import { syncBrandHomeLink } from "./home-link.js";
 import { resolveRootPathForLocale, rootPathField } from "./root-path.js";
 import { brandUsagesField } from "./usages.js";
 
+export type BrandThemeColorOption = {
+  label: Record<string, string> | string;
+  value: string;
+};
+
+const defaultThemeColorOptions: BrandThemeColorOption[] = [
+  { label: "Default", value: "default" },
+];
+
 type BrandsOptions = {
   livePreviewBaseUrl?: string;
+  themeColors?: BrandThemeColorOption[];
 };
 
 export function Brands({
   livePreviewBaseUrl,
+  themeColors,
 }: BrandsOptions): CollectionConfig {
+  const themeColorOptions = themeColors?.length
+    ? themeColors
+    : defaultThemeColorOptions;
+
   return {
     slug: "brands",
     access: {
@@ -32,7 +47,7 @@ export function Brands({
       update: canManageContent,
     },
     admin: {
-      defaultColumns: ["name", "rootPath", "logo", "updatedAt"],
+      defaultColumns: ["name", "rootPath", "themeColor", "logo", "updatedAt"],
       group: contentGroup,
       listSearchableFields: ["id", "name"],
       livePreview: livePreviewBaseUrl
@@ -62,6 +77,7 @@ export function Brands({
       baseTitle: true,
       homeLink: true,
       rootPath: true,
+      themeColor: true,
     },
     defaultSort: "name",
     fields: [
@@ -117,6 +133,23 @@ export function Brands({
                 required: false,
               }),
               rootPathField(),
+              {
+                name: "themeColor",
+                type: "select",
+                admin: {
+                  description: {
+                    en: "Choose the theme color used by the frontend for this brand.",
+                    es: "Elige el color de tema que usará el frontend para esta marca.",
+                  },
+                },
+                defaultValue: themeColorOptions[0]?.value ?? "default",
+                label: {
+                  en: "Theme Color",
+                  es: "Color de tema",
+                },
+                options: themeColorOptions,
+                required: true,
+              },
               textField({
                 name: "baseTitle",
                 admin: {

--- a/libs/cms-plugin/src/collections/brands/migrate-theme-colors.ts
+++ b/libs/cms-plugin/src/collections/brands/migrate-theme-colors.ts
@@ -1,0 +1,138 @@
+import type { Payload, PayloadRequest } from "payload";
+
+type ID = number | string;
+
+type BrandWithThemeColor = {
+  id: ID;
+  themeColor?: unknown;
+};
+
+type FindResult<T> = {
+  docs: T[];
+};
+
+type PayloadFind = (
+  options: Record<string, unknown>,
+) => Promise<FindResult<unknown>>;
+
+type PayloadUpdate = (options: Record<string, unknown>) => Promise<unknown>;
+
+type RequestOptions = {
+  req?: PayloadRequest;
+};
+
+export type MigrateBrandThemeColorsOptions = {
+  brandCollectionSlug?: string;
+  defaultThemeColor?: string;
+  dryRun?: boolean;
+  overwriteExisting?: boolean;
+  payload: Payload;
+  req?: PayloadRequest;
+  themeColorByBrandId?: Record<string, string>;
+};
+
+export type MigrateBrandThemeColorsResult = {
+  brandsAlreadyMigrated: number;
+  brandsProcessed: number;
+  brandsSkipped: number;
+  brandsUpdated: number;
+  brandsUsingDefaultThemeColor: number;
+  dryRun: boolean;
+};
+
+async function findBrands({
+  brandCollectionSlug,
+  find,
+  requestOptions,
+}: {
+  brandCollectionSlug: string;
+  find: PayloadFind;
+  requestOptions: RequestOptions;
+}) {
+  return (
+    await find({
+      collection: brandCollectionSlug,
+      depth: 0,
+      pagination: false,
+      select: {
+        themeColor: true,
+      },
+      showHiddenFields: true,
+      ...requestOptions,
+    })
+  ).docs as BrandWithThemeColor[];
+}
+
+function usableThemeColor(value: unknown) {
+  return typeof value === "string" && value.trim().length > 0
+    ? value.trim()
+    : undefined;
+}
+
+export async function migrateBrandThemeColors({
+  brandCollectionSlug = "brands",
+  defaultThemeColor = "default",
+  dryRun = false,
+  overwriteExisting = false,
+  payload,
+  req,
+  themeColorByBrandId = {},
+}: MigrateBrandThemeColorsOptions): Promise<MigrateBrandThemeColorsResult> {
+  const result: MigrateBrandThemeColorsResult = {
+    brandsAlreadyMigrated: 0,
+    brandsProcessed: 0,
+    brandsSkipped: 0,
+    brandsUpdated: 0,
+    brandsUsingDefaultThemeColor: 0,
+    dryRun,
+  };
+
+  const requestOptions = req ? { req } : {};
+  const find = payload.find.bind(payload) as unknown as PayloadFind;
+  const update = payload.update.bind(payload) as unknown as PayloadUpdate;
+
+  const brands = await findBrands({
+    brandCollectionSlug,
+    find,
+    requestOptions,
+  });
+
+  for (const brand of brands) {
+    result.brandsProcessed += 1;
+
+    const existingThemeColor = usableThemeColor(brand.themeColor);
+    if (existingThemeColor && !overwriteExisting) {
+      result.brandsAlreadyMigrated += 1;
+      result.brandsSkipped += 1;
+      continue;
+    }
+
+    const mappedThemeColor = themeColorByBrandId[String(brand.id)];
+    const themeColor = mappedThemeColor ?? defaultThemeColor;
+    if (!mappedThemeColor) {
+      result.brandsUsingDefaultThemeColor += 1;
+    }
+
+    if (existingThemeColor === themeColor) {
+      result.brandsAlreadyMigrated += 1;
+      result.brandsSkipped += 1;
+      continue;
+    }
+
+    result.brandsUpdated += 1;
+
+    if (!dryRun) {
+      await update({
+        id: brand.id,
+        collection: brandCollectionSlug,
+        data: {
+          themeColor,
+        },
+        overrideAccess: true,
+        ...requestOptions,
+      });
+    }
+  }
+
+  return result;
+}

--- a/libs/cms-plugin/src/collections/brands/migrate-theme-colors.ts
+++ b/libs/cms-plugin/src/collections/brands/migrate-theme-colors.ts
@@ -109,14 +109,15 @@ export async function migrateBrandThemeColors({
 
     const mappedThemeColor = themeColorByBrandId[String(brand.id)];
     const themeColor = mappedThemeColor ?? defaultThemeColor;
-    if (!mappedThemeColor) {
-      result.brandsUsingDefaultThemeColor += 1;
-    }
 
     if (existingThemeColor === themeColor) {
       result.brandsAlreadyMigrated += 1;
       result.brandsSkipped += 1;
       continue;
+    }
+
+    if (!mappedThemeColor) {
+      result.brandsUsingDefaultThemeColor += 1;
     }
 
     result.brandsUpdated += 1;

--- a/libs/cms-plugin/src/collections/pages/config.ts
+++ b/libs/cms-plugin/src/collections/pages/config.ts
@@ -165,8 +165,8 @@ export function Pages({
         },
         admin: {
           description: {
-            en: "Choose the brand to which the page belongs. The brand determines the theme of the page.",
-            es: "Elige la marca a la que pertenece la página. La marca determina el tema de la página.",
+            en: "Choose the brand to which the page belongs. The page pathname must live within the brand's root path.",
+            es: "Elige la marca a la que pertenece la página. La ruta de la página debe estar dentro de la ruta raíz de la marca.",
           },
           position: "sidebar",
         },

--- a/libs/cms-plugin/src/index.ts
+++ b/libs/cms-plugin/src/index.ts
@@ -25,6 +25,7 @@ import { Settings } from "./globals/settings/config.js";
 import { translations } from "./translations/translations.js";
 
 export * from "./collections/brands/migrate-home-links-to-root-paths.js";
+export * from "./collections/brands/migrate-theme-colors.js";
 export * from "./collections/media/migrate-categories-to-folders.js";
 export * from "./common/index.js";
 export * from "./fields/index.js";

--- a/libs/cms-plugin/src/index.ts
+++ b/libs/cms-plugin/src/index.ts
@@ -4,7 +4,10 @@ import { s3Storage } from "@payloadcms/storage-s3";
 
 import { ApiKeys } from "./collections/api-keys/config.js";
 import { Banners } from "./collections/banners/config.js";
-import { Brands } from "./collections/brands/config.js";
+import {
+  Brands,
+  type BrandThemeColorOption,
+} from "./collections/brands/config.js";
 import { LocaleConfigs } from "./collections/locale-configs/config.js";
 import { Media } from "./collections/media/config.js";
 import { MediaCategories } from "./collections/media-categories/config.js";
@@ -67,6 +70,7 @@ export type CmsPluginOptions = {
   openaiApiKey?: string;
   publicMediaBaseUrl?: string;
   serverUrl?: string;
+  themeColors?: BrandThemeColorOption[];
 };
 
 export const cmsPlugin =
@@ -82,6 +86,7 @@ export const cmsPlugin =
     openaiApiKey,
     publicMediaBaseUrl,
     serverUrl,
+    themeColors,
   }: CmsPluginOptions): Plugin =>
   (config: Config) => {
     if (!config.collections) {
@@ -138,7 +143,7 @@ export const cmsPlugin =
       }),
     );
     config.collections.push(Redirects);
-    config.collections.push(Brands({ livePreviewBaseUrl }));
+    config.collections.push(Brands({ livePreviewBaseUrl, themeColors }));
 
     if (!config.globals) {
       config.globals = [];

--- a/libs/cms-plugin/tests/collections/brands/config.test.ts
+++ b/libs/cms-plugin/tests/collections/brands/config.test.ts
@@ -1,0 +1,58 @@
+import type { CollectionConfig, Field } from "payload";
+
+import { describe, expect, it } from "vitest";
+
+import { Brands } from "../../../src/collections/brands/config.js";
+
+type BrandConfigWithPopulate = CollectionConfig & {
+  defaultPopulate?: Record<string, unknown>;
+};
+
+type TabsFieldConfig = {
+  tabs: { fields: Field[] }[];
+  type: "tabs";
+};
+
+function getBrandThemeColorField(config = Brands({})) {
+  const tabsField = config.fields.find(
+    (field): field is TabsFieldConfig => field.type === "tabs",
+  );
+
+  return tabsField?.tabs
+    .flatMap((tab) => tab.fields)
+    .find((field) => "name" in field && field.name === "themeColor");
+}
+
+describe("brand config", () => {
+  it("adds a required theme color select using configured options", () => {
+    const themeColors = [
+      { label: "Aqua", value: "aqua" },
+      { label: "Azul", value: "azul" },
+    ];
+
+    const field = getBrandThemeColorField(Brands({ themeColors }));
+
+    expect(field).toMatchObject({
+      defaultValue: "aqua",
+      name: "themeColor",
+      options: themeColors,
+      required: true,
+      type: "select",
+    });
+  });
+
+  it("falls back to a default theme color option", () => {
+    const field = getBrandThemeColorField();
+
+    expect(field).toMatchObject({
+      defaultValue: "default",
+      options: [{ label: "Default", value: "default" }],
+    });
+  });
+
+  it("populates the theme color by default", () => {
+    const config = Brands({}) as BrandConfigWithPopulate;
+
+    expect(config.defaultPopulate?.themeColor).toBe(true);
+  });
+});

--- a/libs/cms-plugin/tests/collections/brands/migrate-theme-colors.test.ts
+++ b/libs/cms-plugin/tests/collections/brands/migrate-theme-colors.test.ts
@@ -138,4 +138,27 @@ describe("migrateBrandThemeColors", () => {
       overrideAccess: true,
     });
   });
+
+  it("does not count default theme colors for skipped no-op updates", async () => {
+    const payload = {
+      find: vi.fn(async () => ({
+        docs: [{ id: "unmapped", themeColor: "default" }],
+      })),
+      update: vi.fn(),
+    } as unknown as Payload;
+
+    const result = await migrateBrandThemeColors({
+      overwriteExisting: true,
+      payload,
+    });
+
+    expect(result).toMatchObject({
+      brandsAlreadyMigrated: 1,
+      brandsProcessed: 1,
+      brandsSkipped: 1,
+      brandsUpdated: 0,
+      brandsUsingDefaultThemeColor: 0,
+    });
+    expect(payload.update).not.toHaveBeenCalled();
+  });
 });

--- a/libs/cms-plugin/tests/collections/brands/migrate-theme-colors.test.ts
+++ b/libs/cms-plugin/tests/collections/brands/migrate-theme-colors.test.ts
@@ -1,0 +1,141 @@
+import type { Payload } from "payload";
+
+import { describe, expect, it, vi } from "vitest";
+
+import { migrateBrandThemeColors } from "../../../src/collections/brands/migrate-theme-colors.js";
+
+describe("migrateBrandThemeColors", () => {
+  it("backfills missing brand theme colors from brand ID mappings", async () => {
+    const payload = {
+      find: vi.fn(async () => ({
+        docs: [
+          { id: "puerta" },
+          { id: "aqua" },
+          { id: "azul" },
+          { id: "unmapped" },
+        ],
+      })),
+      update: vi.fn(async () => ({})),
+    } as unknown as Payload;
+
+    const result = await migrateBrandThemeColors({
+      defaultThemeColor: "puerta",
+      payload,
+      themeColorByBrandId: {
+        aqua: "aqua",
+        azul: "azul",
+        puerta: "puerta",
+      },
+    });
+
+    expect(result).toEqual({
+      brandsAlreadyMigrated: 0,
+      brandsProcessed: 4,
+      brandsSkipped: 0,
+      brandsUpdated: 4,
+      brandsUsingDefaultThemeColor: 1,
+      dryRun: false,
+    });
+    expect(payload.find).toHaveBeenCalledWith({
+      collection: "brands",
+      depth: 0,
+      pagination: false,
+      select: {
+        themeColor: true,
+      },
+      showHiddenFields: true,
+    });
+    expect(payload.update).toHaveBeenCalledTimes(4);
+    expect(payload.update).toHaveBeenCalledWith({
+      collection: "brands",
+      data: {
+        themeColor: "aqua",
+      },
+      id: "aqua",
+      overrideAccess: true,
+    });
+    expect(payload.update).toHaveBeenCalledWith({
+      collection: "brands",
+      data: {
+        themeColor: "puerta",
+      },
+      id: "unmapped",
+      overrideAccess: true,
+    });
+  });
+
+  it("skips brands that already have theme colors", async () => {
+    const payload = {
+      find: vi.fn(async () => ({
+        docs: [
+          { id: "puerta", themeColor: "puerta" },
+          { id: "aqua", themeColor: "aqua" },
+        ],
+      })),
+      update: vi.fn(),
+    } as unknown as Payload;
+
+    const result = await migrateBrandThemeColors({ payload });
+
+    expect(result).toMatchObject({
+      brandsAlreadyMigrated: 2,
+      brandsProcessed: 2,
+      brandsSkipped: 2,
+      brandsUpdated: 0,
+    });
+    expect(payload.update).not.toHaveBeenCalled();
+  });
+
+  it("supports dry runs without updating brands", async () => {
+    const payload = {
+      find: vi.fn(async () => ({
+        docs: [{ id: "aqua" }],
+      })),
+      update: vi.fn(),
+    } as unknown as Payload;
+
+    const result = await migrateBrandThemeColors({
+      dryRun: true,
+      payload,
+      themeColorByBrandId: { aqua: "aqua" },
+    });
+
+    expect(result).toMatchObject({
+      brandsProcessed: 1,
+      brandsSkipped: 0,
+      brandsUpdated: 1,
+      dryRun: true,
+    });
+    expect(payload.update).not.toHaveBeenCalled();
+  });
+
+  it("can overwrite existing theme colors", async () => {
+    const payload = {
+      find: vi.fn(async () => ({
+        docs: [{ id: "aqua", themeColor: "puerta" }],
+      })),
+      update: vi.fn(async () => ({})),
+    } as unknown as Payload;
+
+    const result = await migrateBrandThemeColors({
+      overwriteExisting: true,
+      payload,
+      themeColorByBrandId: { aqua: "aqua" },
+    });
+
+    expect(result).toMatchObject({
+      brandsAlreadyMigrated: 0,
+      brandsProcessed: 1,
+      brandsSkipped: 0,
+      brandsUpdated: 1,
+    });
+    expect(payload.update).toHaveBeenCalledWith({
+      collection: "brands",
+      data: {
+        themeColor: "aqua",
+      },
+      id: "aqua",
+      overrideAccess: true,
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- add configurable `themeColors` support to `cmsPlugin(...)`
- add a required `themeColor` select field to brands with default population
- add `migrateBrandThemeColors` so existing production brands can be backfilled safely before frontends read `brand.themeColor`
- update page brand helper text, example config, generated Payload types, README migration guidance, and focused brand config/migration tests

## Consumer cross-check
- `fxmkdev/lapuertahostels` currently maps theme data from `brand.id` (`puerta`, `aqua`, `azul`), so it should configure matching `themeColors` and run `migrateBrandThemeColors` with a brand ID mapping before switching frontend theme lookup to `brand.themeColor`.
- `fxmkdev/website` does not currently depend on `@fxmk/cms-plugin`; its `themeColor` fields are unrelated site meta fields, so this plugin migration does not directly affect it.

## Validation
- `pnpm --filter cms-plugin test:int`
- `pnpm --filter cms-plugin build`
- `pnpm --filter cms-example generate:types`
- `pnpm --filter cms-example build`
- `pnpm check`

Note: `pnpm check` passes with existing lint warnings unrelated to this change.