### PR TITLE
ci: publish releases directly

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -240,7 +240,9 @@ jobs:
       - common-build
       - cms-example-build-push
       - version
-    if: needs.version.outputs.is_new_release == 'true'
+    if: >
+      github.event_name != 'pull_request' && github.ref == 'refs/heads/main' &&
+      needs.version.outputs.is_new_release == 'true'
     permissions:
       contents: write
     steps:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -254,7 +254,7 @@ jobs:
         run: pnpm --workspace-root install
       - name: Create release
         run: |
-          pnpm releaser publish --draft ${{ needs.version.outputs.version }}
+          pnpm releaser publish ${{ needs.version.outputs.version }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/export.build.yml
+++ b/.github/workflows/export.build.yml
@@ -363,7 +363,7 @@ jobs:
         run: pnpm --workspace-root install
       - name: Create release
         run: |
-          pnpm releaser publish --draft ${{ needs.version.outputs.version }}
+          pnpm releaser publish ${{ needs.version.outputs.version }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/export.build.yml
+++ b/.github/workflows/export.build.yml
@@ -348,7 +348,9 @@ jobs:
   create-release:
     name: Create release
     runs-on: ubuntu-latest
-    if: needs.version.outputs.is_new_release == 'true'
+    if: >
+      github.event_name != 'pull_request' && github.ref == 'refs/heads/main' &&
+      needs.version.outputs.is_new_release == 'true'
     needs: [deploy, version]
     permissions:
       contents: write


### PR DESCRIPTION
## Summary

- publish GitHub releases directly by removing the releaser `--draft` flag
- apply the behavior to both main and export build workflows
- guard direct release jobs so they only run outside pull request events and on `refs/heads/main`

## Validation

- `pnpm format:check`
- `rg -n -- "--draft|draft" .github`

## Review follow-up

- resolved Copilot review threads by adding explicit event/ref guards before release publication