### PR TITLE
ci: pass app version to exported Docker builds

### DIFF
--- a/.github/workflows/export.build.yml
+++ b/.github/workflows/export.build.yml
@@ -106,10 +106,6 @@ jobs:
           version: ${{ env.FLYCTL_VERSION }}
       - name: Setup
         uses: felixmokross/webplatform/.github/actions/setup@main
-      - name: Set version on frontend
-        run: |
-          pnpm version ${{ needs.version.outputs.version }} --git-tag-version false
-        working-directory: apps/frontend
       - name: Download CMS types
         uses: actions/download-artifact@v8
         with:
@@ -129,6 +125,7 @@ jobs:
             --app ${{ steps.image-name.outputs.image_name }} \
             --config apps/frontend/fly.build.toml \
             --build-only \
+            --build-arg APP_VERSION=${{ needs.version.outputs.version }} \
             --image-label ${{ steps.image-name.outputs.image_tag }} \
             --label org.opencontainers.image.version=${{ steps.image-name.outputs.image_tag }} \
             --push \
@@ -207,10 +204,6 @@ jobs:
           version: ${{ env.FLYCTL_VERSION }}
       - name: Setup
         uses: felixmokross/webplatform/.github/actions/setup@main
-      - name: Set version on CMS
-        run: |
-          pnpm version ${{ needs.version.outputs.version }} --git-tag-version false
-        working-directory: apps/cms
       - name: Get CMS image name
         id: image-name
         run: |
@@ -225,6 +218,7 @@ jobs:
             --app ${{ steps.image-name.outputs.image_name }} \
             --config apps/cms/fly.build.toml \
             --build-only \
+            --build-arg APP_VERSION=${{ needs.version.outputs.version }} \
             --image-label ${{ steps.image-name.outputs.image_tag }} \
             --label org.opencontainers.image.version=${{ steps.image-name.outputs.image_tag }} \
             --push \


### PR DESCRIPTION
## Summary
- remove checkout-time package version mutations from the exported build workflow
- pass the generated release version into frontend and CMS Docker builds as APP_VERSION
- preserve existing image tags and OCI version labels based on version_with_sha

## Validation
- pnpm format:check
- git diff --check

## Consumer impact
Consumers that want app-level versions embedded in their images should adapt their Dockerfiles to accept ARG APP_VERSION and write it inside Docker after cache-sensitive dependency layers.