### PR TITLE
fix(cms-plugin): improve new page pathname UX

### DIFF
--- a/libs/cms-plugin/src/collections/pages/pathname-field.ts
+++ b/libs/cms-plugin/src/collections/pages/pathname-field.ts
@@ -94,6 +94,11 @@ const createRedirectForPreviousPathname: FieldHook = async ({
     return;
   }
 
+  const previousPageId = previousDoc.id as string | undefined;
+  if (!previousPageId) {
+    return;
+  }
+
   const redirects = await req.payload.find({
     collection: "redirects",
     pagination: false,
@@ -113,7 +118,7 @@ const createRedirectForPreviousPathname: FieldHook = async ({
     collection: "redirects",
     data: {
       fromPathname: previousValue,
-      to: { page: previousDoc.id },
+      to: { page: previousPageId },
     },
   });
 };

--- a/libs/cms-plugin/src/components/client/pathname-field.tsx
+++ b/libs/cms-plugin/src/components/client/pathname-field.tsx
@@ -7,6 +7,7 @@ import {
   FieldDescription,
   FieldLabel,
   TextInput,
+  useDocumentInfo,
   useField,
   useForm,
   useFormFields,
@@ -24,6 +25,7 @@ export function PathnameField({ field, path }: TextFieldClientProps) {
   const { initialValue, setValue, showError, value } = useField<string>({
     path,
   });
+  const { id } = useDocumentInfo();
 
   const { dispatchFields } = useForm();
   const [isLocked, createRedirect] = useFormFields(([fields]) => {
@@ -35,7 +37,11 @@ export function PathnameField({ field, path }: TextFieldClientProps) {
 
   const { t } = useTranslation<TranslationsObject, TranslationsKey>();
 
-  const isChanged = initialValue !== value;
+  const hasExistingPage = Boolean(id);
+  const hasInitialPathname =
+    typeof initialValue === "string" && initialValue.length > 0;
+  const shouldShowCreateRedirect =
+    hasExistingPage && hasInitialPathname && initialValue !== value;
 
   return (
     <div className="field-type">
@@ -47,21 +53,23 @@ export function PathnameField({ field, path }: TextFieldClientProps) {
           required={field.required}
         />
 
-        <button
-          className={styles.lockButton}
-          onClick={() =>
-            dispatchFields({
-              type: "UPDATE",
-              path: "pathname_locked",
-              value: !isLocked,
-            })
-          }
-          type="button"
-        >
-          {isLocked
-            ? t("cmsPlugin:pages:pathname:unlock")
-            : t("cmsPlugin:pages:pathname:lock")}
-        </button>
+        {hasExistingPage && (
+          <button
+            className={styles.lockButton}
+            onClick={() =>
+              dispatchFields({
+                type: "UPDATE",
+                path: "pathname_locked",
+                value: !isLocked,
+              })
+            }
+            type="button"
+          >
+            {isLocked
+              ? t("cmsPlugin:pages:pathname:unlock")
+              : t("cmsPlugin:pages:pathname:lock")}
+          </button>
+        )}
       </div>
 
       <TextInput
@@ -69,12 +77,12 @@ export function PathnameField({ field, path }: TextFieldClientProps) {
         onChange={setValue}
         path={path}
         placeholder={field.admin?.placeholder}
-        readOnly={isLocked}
+        readOnly={hasExistingPage && isLocked}
         required={field.required}
         showError={showError}
         value={value}
       />
-      {isChanged && (
+      {shouldShowCreateRedirect && (
         <CheckboxInput
           checked={createRedirect}
           className={styles.createRedirectCheckbox}


### PR DESCRIPTION
## Summary

- Make the page pathname field editable by default while creating a new page.
- Hide the lock/unlock affordance and redirect checkbox for unsaved pages.
- Keep existing page pathname locking and redirect creation behavior intact.
- Add a defensive guard so redirect creation requires a previous page id.

## Rebase Notes

- Rebased on latest `origin/main` (`90ad96f`).
- Resolved the page collection split conflict by keeping `main`'s new module layout and moving the redirect guard into `libs/cms-plugin/src/collections/pages/pathname-field.ts`.

## Validation

- `pnpm --filter cms-plugin lint` passed with existing warnings only.
- `pnpm --filter cms-plugin build` passed.
- `pnpm --filter cms-plugin test:int` passed, 58 tests across 10 files.

## Manual QA

Not run locally: this worktree has no `examples/cms-example/.env` and no `DATABASE_URI`/`PAYLOAD_SECRET`, so the Payload admin cannot boot meaningfully here.
