### PR TITLE
fix(cms-plugin): retry media folder migration writes

### DIFF
--- a/libs/cms-plugin/README.md
+++ b/libs/cms-plugin/README.md
@@ -136,6 +136,17 @@ By default the migration helper creates or reuses top-level folders. Pass
 `parentFolderID` if migrated category folders should live under a specific
 existing folder.
 
+The helper retries retryable MongoDB transaction/catalog-change errors by
+default, including `TransientTransactionError` and `WriteConflict`. This makes
+first deploys less flaky when Payload introduces the `payload-folders`
+collection and the migration immediately writes folders.
+
+Because Payload runs migrations in a transaction when `req` is passed, the
+helper defaults to `disableTransaction: true` for its Local API calls and relies
+on its idempotent folder reuse and media-skip behavior across retries. Pass
+`disableTransaction: false` to keep all helper writes inside Payload's migration
+transaction, or `retry: false` to disable helper retries.
+
 ## Building the Plugin
 
 When you build a plugin, you are purely building a feature for your project and

--- a/libs/cms-plugin/README.md
+++ b/libs/cms-plugin/README.md
@@ -136,10 +136,10 @@ By default the migration helper creates or reuses top-level folders. Pass
 `parentFolderID` if migrated category folders should live under a specific
 existing folder.
 
-The helper retries retryable MongoDB transaction/catalog-change errors by
-default, including `TransientTransactionError` and `WriteConflict`. This makes
-first deploys less flaky when Payload introduces the `payload-folders`
-collection and the migration immediately writes folders.
+The helper automatically retries transient MongoDB transaction/catalog-change
+errors by default, including `TransientTransactionError` and `WriteConflict`.
+This makes first deploys less flaky when Payload introduces the
+`payload-folders` collection and the migration immediately writes folders.
 
 Because Payload runs migrations in a transaction when `req` is passed, the
 helper defaults to `disableTransaction: true` for its Local API calls and relies

--- a/libs/cms-plugin/src/collections/media/migrate-categories-to-folders.ts
+++ b/libs/cms-plugin/src/collections/media/migrate-categories-to-folders.ts
@@ -71,6 +71,18 @@ type CategoryMigrationResult = Pick<
   "foldersCreated" | "foldersReused" | "mediaSkipped" | "mediaUpdated"
 >;
 
+type MediaAssignmentResult = Pick<
+  MigrateMediaCategoriesToFoldersResult,
+  "mediaSkipped" | "mediaUpdated"
+>;
+
+type FolderResolutionResult = {
+  folderID: ID;
+} & Pick<
+  MigrateMediaCategoriesToFoldersResult,
+  "foldersCreated" | "foldersReused"
+>;
+
 type RetryOptions = Required<MigrateMediaCategoriesToFoldersRetryOptions>;
 
 const DEFAULT_RETRY_OPTIONS: RetryOptions = {
@@ -408,6 +420,111 @@ async function findReusableFolder({
   );
 }
 
+async function assignMediaToFolder({
+  dryRun,
+  folderFieldName,
+  folderID,
+  media,
+  mediaCollectionSlug,
+  requestOptions,
+  update,
+}: {
+  dryRun: boolean;
+  folderFieldName: string;
+  folderID: ID;
+  media: MediaWithLegacyCategory[];
+  mediaCollectionSlug: string;
+  requestOptions: RequestOptions;
+  update: PayloadUpdate;
+}): Promise<MediaAssignmentResult> {
+  const result: MediaAssignmentResult = {
+    mediaSkipped: 0,
+    mediaUpdated: 0,
+  };
+
+  for (const mediaItem of media) {
+    if (relationshipID(mediaItem[folderFieldName])) {
+      result.mediaSkipped += 1;
+      continue;
+    }
+
+    result.mediaUpdated += 1;
+
+    if (!dryRun) {
+      await update({
+        id: mediaItem.id,
+        collection: mediaCollectionSlug,
+        data: {
+          [folderFieldName]: folderID,
+        },
+        ...requestOptions,
+      });
+    }
+  }
+
+  return result;
+}
+
+async function folderForCategory({
+  category,
+  categoryNameCounts,
+  create,
+  dryRun,
+  find,
+  folderCollectionSlug,
+  folderFieldName,
+  folderType,
+  parentFolderID,
+  requestOptions,
+}: {
+  category: LegacyMediaCategory;
+  categoryNameCounts: Map<string, number>;
+  create: PayloadCreate;
+  dryRun: boolean;
+  find: PayloadFind;
+  folderCollectionSlug: string;
+  folderFieldName: string;
+  folderType: false | string;
+  parentFolderID?: ID;
+  requestOptions: RequestOptions;
+}): Promise<FolderResolutionResult> {
+  const folderName = folderNameForCategory(category, categoryNameCounts);
+  const parentFolder = parentFolderID ?? null;
+  const folder = await findReusableFolder({
+    find,
+    folderCollectionSlug,
+    folderFieldName,
+    folderName,
+    folderType,
+    parentFolder,
+    requestOptions,
+  });
+
+  const folderID =
+    folder?.id ??
+    (dryRun
+      ? `dry-run:${category.id}`
+      : await createFolder({
+          create,
+          folderCollectionSlug,
+          folderFieldName,
+          folderName,
+          folderType,
+          parentFolder,
+          requestOptions,
+        }));
+
+  if (!folderID) {
+    throw new Error(`Failed to create folder for category "${category.name}"`);
+  }
+
+  return {
+    folderID,
+    foldersCreated: folder ? 0 : 1,
+    foldersReused: folder ? 1 : 0,
+  };
+}
+
 async function migrateCategoryToFolder({
   category,
   categoryNameCounts,
@@ -442,41 +559,20 @@ async function migrateCategoryToFolder({
     mediaUpdated: 0,
   };
 
-  const folderName = folderNameForCategory(category, categoryNameCounts);
-  const parentFolder = parentFolderID ?? null;
-  const folder = await findReusableFolder({
+  const folderResult = await folderForCategory({
+    category,
+    categoryNameCounts,
+    create,
+    dryRun,
     find,
     folderCollectionSlug,
     folderFieldName,
-    folderName,
     folderType,
-    parentFolder,
+    parentFolderID,
     requestOptions,
   });
-
-  const folderID =
-    folder?.id ??
-    (dryRun
-      ? `dry-run:${category.id}`
-      : await createFolder({
-          create,
-          folderCollectionSlug,
-          folderFieldName,
-          folderName,
-          folderType,
-          parentFolder,
-          requestOptions,
-        }));
-
-  if (!folderID) {
-    throw new Error(`Failed to create folder for category "${category.name}"`);
-  }
-
-  if (folder) {
-    result.foldersReused += 1;
-  } else {
-    result.foldersCreated += 1;
-  }
+  result.foldersCreated += folderResult.foldersCreated;
+  result.foldersReused += folderResult.foldersReused;
 
   const media = await findMediaForCategory({
     categoryID: category.id,
@@ -485,25 +581,17 @@ async function migrateCategoryToFolder({
     requestOptions,
   });
 
-  for (const mediaItem of media) {
-    if (relationshipID(mediaItem[folderFieldName])) {
-      result.mediaSkipped += 1;
-      continue;
-    }
-
-    result.mediaUpdated += 1;
-
-    if (!dryRun) {
-      await update({
-        id: mediaItem.id,
-        collection: mediaCollectionSlug,
-        data: {
-          [folderFieldName]: folderID,
-        },
-        ...requestOptions,
-      });
-    }
-  }
+  const mediaAssignmentResult = await assignMediaToFolder({
+    dryRun,
+    folderFieldName,
+    folderID: folderResult.folderID,
+    media,
+    mediaCollectionSlug,
+    requestOptions,
+    update,
+  });
+  result.mediaSkipped += mediaAssignmentResult.mediaSkipped;
+  result.mediaUpdated += mediaAssignmentResult.mediaUpdated;
 
   return result;
 }

--- a/libs/cms-plugin/src/collections/media/migrate-categories-to-folders.ts
+++ b/libs/cms-plugin/src/collections/media/migrate-categories-to-folders.ts
@@ -21,6 +21,7 @@ type FolderDocument = {
 
 export type MigrateMediaCategoriesToFoldersOptions = {
   categoryCollectionSlug?: string;
+  disableTransaction?: boolean;
   dryRun?: boolean;
   folderCollectionSlug?: string;
   folderFieldName?: string;
@@ -29,6 +30,14 @@ export type MigrateMediaCategoriesToFoldersOptions = {
   parentFolderID?: ID;
   payload: Payload;
   req?: PayloadRequest;
+  retry?: false | MigrateMediaCategoriesToFoldersRetryOptions;
+};
+
+export type MigrateMediaCategoriesToFoldersRetryOptions = {
+  attempts?: number;
+  backoffFactor?: number;
+  initialDelayMs?: number;
+  maxDelayMs?: number;
 };
 
 export type MigrateMediaCategoriesToFoldersResult = {
@@ -53,8 +62,163 @@ type PayloadFind = (
 type PayloadUpdate = (options: Record<string, unknown>) => Promise<unknown>;
 
 type RequestOptions = {
+  disableTransaction?: boolean;
   req?: PayloadRequest;
 };
+
+type CategoryMigrationResult = Pick<
+  MigrateMediaCategoriesToFoldersResult,
+  "foldersCreated" | "foldersReused" | "mediaSkipped" | "mediaUpdated"
+>;
+
+type RetryOptions = Required<MigrateMediaCategoriesToFoldersRetryOptions>;
+
+const DEFAULT_RETRY_OPTIONS: RetryOptions = {
+  attempts: 4,
+  backoffFactor: 2,
+  initialDelayMs: 100,
+  maxDelayMs: 1_000,
+};
+
+const RETRYABLE_ERROR_LABELS = new Set([
+  "TransientTransactionError",
+  "UnknownTransactionCommitResult",
+]);
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return Boolean(value && typeof value === "object" && !Array.isArray(value));
+}
+
+function normalizeRetryOptions(
+  retry: false | MigrateMediaCategoriesToFoldersRetryOptions | undefined,
+) {
+  if (retry === false) {
+    return false;
+  }
+
+  return {
+    attempts: Math.max(
+      1,
+      Math.floor(retry?.attempts ?? DEFAULT_RETRY_OPTIONS.attempts),
+    ),
+    backoffFactor: Math.max(
+      1,
+      retry?.backoffFactor ?? DEFAULT_RETRY_OPTIONS.backoffFactor,
+    ),
+    initialDelayMs: Math.max(
+      0,
+      retry?.initialDelayMs ?? DEFAULT_RETRY_OPTIONS.initialDelayMs,
+    ),
+    maxDelayMs: Math.max(
+      0,
+      retry?.maxDelayMs ?? DEFAULT_RETRY_OPTIONS.maxDelayMs,
+    ),
+  };
+}
+
+function retryDelayMs(retryOptions: RetryOptions, attempt: number) {
+  const delay =
+    retryOptions.initialDelayMs *
+    retryOptions.backoffFactor ** Math.max(0, attempt - 1);
+
+  return Math.min(delay, retryOptions.maxDelayMs);
+}
+
+async function wait(ms: number) {
+  if (ms === 0) {
+    return;
+  }
+
+  await new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function hasRetryableErrorLabel(error: Record<string, unknown>) {
+  if (
+    "hasErrorLabel" in error &&
+    typeof error.hasErrorLabel === "function" &&
+    [...RETRYABLE_ERROR_LABELS].some((label) =>
+      (error.hasErrorLabel as (label: string) => boolean)(label),
+    )
+  ) {
+    return true;
+  }
+
+  if (!Array.isArray(error.errorLabels)) {
+    return false;
+  }
+
+  return error.errorLabels.some(
+    (label) => typeof label === "string" && RETRYABLE_ERROR_LABELS.has(label),
+  );
+}
+
+function isRetryableMongoMigrationError(
+  error: unknown,
+  seen = new Set<unknown>(),
+): boolean {
+  if (!isPlainObject(error) || seen.has(error)) {
+    return false;
+  }
+  seen.add(error);
+
+  if (hasRetryableErrorLabel(error)) {
+    return true;
+  }
+
+  if (error.codeName === "WriteConflict" || error.code === 112) {
+    return true;
+  }
+
+  if (
+    typeof error.message === "string" &&
+    /catalog changes.*retry|please retry.*transaction/i.test(error.message)
+  ) {
+    return true;
+  }
+
+  if (isRetryableMongoMigrationError(error.cause, seen)) {
+    return true;
+  }
+
+  if (Array.isArray(error.errors)) {
+    return error.errors.some((nestedError) =>
+      isRetryableMongoMigrationError(nestedError, seen),
+    );
+  }
+
+  return false;
+}
+
+async function retryTransientMongoError<T>({
+  operation,
+  retryOptions,
+}: {
+  operation: () => Promise<T>;
+  retryOptions: false | RetryOptions;
+}) {
+  if (retryOptions === false) {
+    return operation();
+  }
+
+  let lastError: unknown;
+  for (let attempt = 1; attempt <= retryOptions.attempts; attempt += 1) {
+    try {
+      return await operation();
+    } catch (error) {
+      lastError = error;
+      if (
+        attempt === retryOptions.attempts ||
+        !isRetryableMongoMigrationError(error)
+      ) {
+        throw error;
+      }
+
+      await wait(retryDelayMs(retryOptions, attempt));
+    }
+  }
+
+  throw lastError;
+}
 
 function relationshipID(value: unknown): ID | undefined {
   if (typeof value === "number" || typeof value === "string") {
@@ -224,8 +388,109 @@ async function findReusableFolder({
   );
 }
 
+async function migrateCategoryToFolder({
+  category,
+  categoryNameCounts,
+  create,
+  dryRun,
+  find,
+  folderCollectionSlug,
+  folderFieldName,
+  folderType,
+  mediaCollectionSlug,
+  parentFolderID,
+  requestOptions,
+  update,
+}: {
+  category: LegacyMediaCategory;
+  categoryNameCounts: Map<string, number>;
+  create: PayloadCreate;
+  dryRun: boolean;
+  find: PayloadFind;
+  folderCollectionSlug: string;
+  folderFieldName: string;
+  folderType: false | string;
+  mediaCollectionSlug: string;
+  parentFolderID?: ID;
+  requestOptions: RequestOptions;
+  update: PayloadUpdate;
+}): Promise<CategoryMigrationResult> {
+  const result: CategoryMigrationResult = {
+    foldersCreated: 0,
+    foldersReused: 0,
+    mediaSkipped: 0,
+    mediaUpdated: 0,
+  };
+
+  const folderName = folderNameForCategory(category, categoryNameCounts);
+  const parentFolder = parentFolderID ?? null;
+  const folder = await findReusableFolder({
+    find,
+    folderCollectionSlug,
+    folderFieldName,
+    folderName,
+    folderType,
+    parentFolder,
+    requestOptions,
+  });
+
+  const folderID =
+    folder?.id ??
+    (dryRun
+      ? `dry-run:${category.id}`
+      : await createFolder({
+          create,
+          folderCollectionSlug,
+          folderFieldName,
+          folderName,
+          folderType,
+          parentFolder,
+          requestOptions,
+        }));
+
+  if (!folderID) {
+    throw new Error(`Failed to create folder for category "${category.name}"`);
+  }
+
+  if (folder) {
+    result.foldersReused += 1;
+  } else {
+    result.foldersCreated += 1;
+  }
+
+  const media = await findMediaForCategory({
+    categoryID: category.id,
+    find,
+    mediaCollectionSlug,
+    requestOptions,
+  });
+
+  for (const mediaItem of media) {
+    if (relationshipID(mediaItem[folderFieldName])) {
+      result.mediaSkipped += 1;
+      continue;
+    }
+
+    result.mediaUpdated += 1;
+
+    if (!dryRun) {
+      await update({
+        id: mediaItem.id,
+        collection: mediaCollectionSlug,
+        data: {
+          [folderFieldName]: folderID,
+        },
+        ...requestOptions,
+      });
+    }
+  }
+
+  return result;
+}
+
 export async function migrateMediaCategoriesToFolders({
   categoryCollectionSlug = "mediaCategory",
+  disableTransaction = true,
   dryRun = false,
   folderCollectionSlug = "payload-folders",
   folderFieldName = "folder",
@@ -234,6 +499,7 @@ export async function migrateMediaCategoriesToFolders({
   parentFolderID,
   payload,
   req,
+  retry,
 }: MigrateMediaCategoriesToFoldersOptions): Promise<MigrateMediaCategoriesToFoldersResult> {
   const result: MigrateMediaCategoriesToFoldersResult = {
     categoriesProcessed: 0,
@@ -244,7 +510,8 @@ export async function migrateMediaCategoriesToFolders({
     mediaUpdated: 0,
   };
 
-  const requestOptions = req ? { req } : {};
+  const requestOptions = { disableTransaction, ...(req ? { req } : {}) };
+  const retryOptions = normalizeRetryOptions(retry);
   const find = payload.find.bind(payload) as unknown as PayloadFind;
   const create = payload.create.bind(payload) as unknown as PayloadCreate;
   const update = payload.update.bind(payload) as unknown as PayloadUpdate;
@@ -261,72 +528,30 @@ export async function migrateMediaCategoriesToFolders({
   }, new Map<string, number>());
 
   for (const category of categories) {
+    const categoryResult = await retryTransientMongoError({
+      operation: () =>
+        migrateCategoryToFolder({
+          category,
+          categoryNameCounts,
+          create,
+          dryRun,
+          find,
+          folderCollectionSlug,
+          folderFieldName,
+          folderType,
+          mediaCollectionSlug,
+          parentFolderID,
+          requestOptions,
+          update,
+        }),
+      retryOptions,
+    });
+
     result.categoriesProcessed += 1;
-
-    const folderName = folderNameForCategory(category, categoryNameCounts);
-    const parentFolder = parentFolderID ?? null;
-    const folder = await findReusableFolder({
-      find,
-      folderCollectionSlug,
-      folderFieldName,
-      folderName,
-      folderType,
-      parentFolder,
-      requestOptions,
-    });
-
-    const folderID =
-      folder?.id ??
-      (dryRun
-        ? `dry-run:${category.id}`
-        : await createFolder({
-            create,
-            folderCollectionSlug,
-            folderFieldName,
-            folderName,
-            folderType,
-            parentFolder,
-            requestOptions,
-          }));
-
-    if (!folderID) {
-      throw new Error(
-        `Failed to create folder for category "${category.name}"`,
-      );
-    }
-
-    if (folder) {
-      result.foldersReused += 1;
-    } else {
-      result.foldersCreated += 1;
-    }
-
-    const media = await findMediaForCategory({
-      categoryID: category.id,
-      find,
-      mediaCollectionSlug,
-      requestOptions,
-    });
-
-    for (const mediaItem of media) {
-      if (relationshipID(mediaItem[folderFieldName])) {
-        result.mediaSkipped += 1;
-        continue;
-      }
-
-      result.mediaUpdated += 1;
-
-      if (!dryRun) {
-        await update({
-          id: mediaItem.id,
-          collection: mediaCollectionSlug,
-          data: {
-            [folderFieldName]: folderID,
-          },
-          ...requestOptions,
-        });
-      }
-    }
+    result.foldersCreated += categoryResult.foldersCreated;
+    result.foldersReused += categoryResult.foldersReused;
+    result.mediaSkipped += categoryResult.mediaSkipped;
+    result.mediaUpdated += categoryResult.mediaUpdated;
   }
 
   return result;

--- a/libs/cms-plugin/src/collections/media/migrate-categories-to-folders.ts
+++ b/libs/cms-plugin/src/collections/media/migrate-categories-to-folders.ts
@@ -85,6 +85,15 @@ const RETRYABLE_ERROR_LABELS = new Set([
   "UnknownTransactionCommitResult",
 ]);
 
+function finiteNumberOrDefault(
+  value: number | undefined,
+  defaultValue: number,
+) {
+  return typeof value === "number" && Number.isFinite(value)
+    ? value
+    : defaultValue;
+}
+
 function isPlainObject(value: unknown): value is Record<string, unknown> {
   return Boolean(value && typeof value === "object" && !Array.isArray(value));
 }
@@ -99,19 +108,30 @@ function normalizeRetryOptions(
   return {
     attempts: Math.max(
       1,
-      Math.floor(retry?.attempts ?? DEFAULT_RETRY_OPTIONS.attempts),
+      Math.floor(
+        finiteNumberOrDefault(retry?.attempts, DEFAULT_RETRY_OPTIONS.attempts),
+      ),
     ),
     backoffFactor: Math.max(
       1,
-      retry?.backoffFactor ?? DEFAULT_RETRY_OPTIONS.backoffFactor,
+      finiteNumberOrDefault(
+        retry?.backoffFactor,
+        DEFAULT_RETRY_OPTIONS.backoffFactor,
+      ),
     ),
     initialDelayMs: Math.max(
       0,
-      retry?.initialDelayMs ?? DEFAULT_RETRY_OPTIONS.initialDelayMs,
+      finiteNumberOrDefault(
+        retry?.initialDelayMs,
+        DEFAULT_RETRY_OPTIONS.initialDelayMs,
+      ),
     ),
     maxDelayMs: Math.max(
       0,
-      retry?.maxDelayMs ?? DEFAULT_RETRY_OPTIONS.maxDelayMs,
+      finiteNumberOrDefault(
+        retry?.maxDelayMs,
+        DEFAULT_RETRY_OPTIONS.maxDelayMs,
+      ),
     ),
   };
 }

--- a/libs/cms-plugin/tests/media-organization.test.ts
+++ b/libs/cms-plugin/tests/media-organization.test.ts
@@ -468,6 +468,43 @@ describe("migrateMediaCategoriesToFolders", () => {
     expect(payload.create).toHaveBeenCalledOnce();
   });
 
+  it("falls back to default retry options for non-finite values", async () => {
+    const payload = {
+      create: vi
+        .fn()
+        .mockRejectedValueOnce(transientTransactionError())
+        .mockResolvedValueOnce({ id: "folder-1" }),
+      find: vi.fn(async (options) => {
+        if (options.collection === "mediaCategory") {
+          return { docs: [{ id: "category-1", name: "Rooms" }] };
+        }
+
+        if (options.collection === "payload-folders") {
+          return { docs: [] };
+        }
+
+        return { docs: [{ id: "media-1" }] };
+      }),
+      update: vi.fn(async () => ({})),
+    } as unknown as Payload;
+
+    const result = await migrateMediaCategoriesToFolders({
+      payload,
+      retry: {
+        attempts: Number.NaN,
+        backoffFactor: Number.NaN,
+        initialDelayMs: 0,
+        maxDelayMs: Number.NaN,
+      },
+    });
+
+    expect(result).toMatchObject({
+      foldersCreated: 1,
+      mediaUpdated: 1,
+    });
+    expect(payload.create).toHaveBeenCalledTimes(2);
+  });
+
   it("can disable retries", async () => {
     const payload = {
       create: vi.fn(async () => {

--- a/libs/cms-plugin/tests/media-organization.test.ts
+++ b/libs/cms-plugin/tests/media-organization.test.ts
@@ -105,6 +105,18 @@ describe("media organization config", () => {
 });
 
 describe("migrateMediaCategoriesToFolders", () => {
+  const retryWithoutDelay = {
+    initialDelayMs: 0,
+  };
+
+  function transientTransactionError() {
+    return Object.assign(new Error("Unable to write due to catalog changes"), {
+      code: 112,
+      codeName: "WriteConflict",
+      errorLabels: ["TransientTransactionError"],
+    });
+  }
+
   it("creates folders and assigns media that do not already have a folder", async () => {
     const payload = {
       create: vi.fn(async () => ({ id: "folder-1" })),
@@ -143,10 +155,12 @@ describe("migrateMediaCategoriesToFolders", () => {
         folderType: ["media"],
         name: "Rooms",
       },
+      disableTransaction: true,
     });
     expect(payload.update).toHaveBeenCalledWith({
       collection: "media",
       data: { folder: "folder-1" },
+      disableTransaction: true,
       id: "media-1",
     });
   });
@@ -219,6 +233,7 @@ describe("migrateMediaCategoriesToFolders", () => {
     expect(payload.update).toHaveBeenCalledWith({
       collection: "media",
       data: { folder: "folder-1" },
+      disableTransaction: true,
       id: "media-1",
     });
   });
@@ -262,10 +277,12 @@ describe("migrateMediaCategoriesToFolders", () => {
         folderType: ["media"],
         name: "Rooms",
       },
+      disableTransaction: true,
     });
     expect(payload.update).toHaveBeenCalledWith({
       collection: "media",
       data: { folder: "top-level-folder" },
+      disableTransaction: true,
       id: "media-1",
     });
   });
@@ -305,6 +322,210 @@ describe("migrateMediaCategoriesToFolders", () => {
     expect(payload.update).toHaveBeenCalledWith({
       collection: "media",
       data: { folder: "nested-folder" },
+      disableTransaction: true,
+      id: "media-1",
+    });
+  });
+
+  it("retries folder creation after transient Mongo transaction errors", async () => {
+    const payload = {
+      create: vi
+        .fn()
+        .mockRejectedValueOnce(transientTransactionError())
+        .mockResolvedValueOnce({ id: "folder-1" }),
+      find: vi.fn(async (options) => {
+        if (options.collection === "mediaCategory") {
+          return { docs: [{ id: "category-1", name: "Rooms" }] };
+        }
+
+        if (options.collection === "payload-folders") {
+          return { docs: [] };
+        }
+
+        return { docs: [{ id: "media-1" }] };
+      }),
+      update: vi.fn(async () => ({})),
+    } as unknown as Payload;
+
+    const result = await migrateMediaCategoriesToFolders({
+      payload,
+      retry: retryWithoutDelay,
+    });
+
+    expect(result).toMatchObject({
+      categoriesProcessed: 1,
+      foldersCreated: 1,
+      mediaUpdated: 1,
+    });
+    expect(payload.create).toHaveBeenCalledTimes(2);
+    expect(payload.find).toHaveBeenCalledWith({
+      collection: "payload-folders",
+      depth: 0,
+      disableTransaction: true,
+      limit: 100,
+      where: {
+        name: {
+          equals: "Rooms",
+        },
+        or: [
+          {
+            folder: {
+              exists: false,
+            },
+          },
+          {
+            folder: {
+              equals: null,
+            },
+          },
+        ],
+      },
+    });
+  });
+
+  it("retries media updates without double-counting partial attempts", async () => {
+    let folderFinds = 0;
+    let mediaFinds = 0;
+    const payload = {
+      create: vi.fn(async () => ({ id: "folder-1" })),
+      find: vi.fn(async (options) => {
+        if (options.collection === "mediaCategory") {
+          return { docs: [{ id: "category-1", name: "Rooms" }] };
+        }
+
+        if (options.collection === "payload-folders") {
+          folderFinds += 1;
+
+          return {
+            docs:
+              folderFinds === 1
+                ? []
+                : [
+                    {
+                      folderType: ["media"],
+                      id: "folder-1",
+                      name: "Rooms",
+                    },
+                  ],
+          };
+        }
+
+        mediaFinds += 1;
+
+        return {
+          docs:
+            mediaFinds === 1
+              ? [{ id: "media-1" }, { id: "media-2" }]
+              : [{ folder: "folder-1", id: "media-1" }, { id: "media-2" }],
+        };
+      }),
+      update: vi
+        .fn()
+        .mockResolvedValueOnce({})
+        .mockRejectedValueOnce(transientTransactionError())
+        .mockResolvedValueOnce({}),
+    } as unknown as Payload;
+
+    const result = await migrateMediaCategoriesToFolders({
+      payload,
+      retry: retryWithoutDelay,
+    });
+
+    expect(result).toEqual({
+      categoriesProcessed: 1,
+      dryRun: false,
+      foldersCreated: 0,
+      foldersReused: 1,
+      mediaSkipped: 1,
+      mediaUpdated: 1,
+    });
+    expect(payload.create).toHaveBeenCalledOnce();
+    expect(payload.update).toHaveBeenCalledTimes(3);
+  });
+
+  it("does not retry non-retryable errors", async () => {
+    const error = new Error("Validation failed");
+    const payload = {
+      create: vi.fn(async () => {
+        throw error;
+      }),
+      find: vi.fn(async (options) => {
+        if (options.collection === "mediaCategory") {
+          return { docs: [{ id: "category-1", name: "Rooms" }] };
+        }
+
+        return { docs: [] };
+      }),
+      update: vi.fn(),
+    } as unknown as Payload;
+
+    await expect(
+      migrateMediaCategoriesToFolders({
+        payload,
+        retry: retryWithoutDelay,
+      }),
+    ).rejects.toThrow(error);
+    expect(payload.create).toHaveBeenCalledOnce();
+  });
+
+  it("can disable retries", async () => {
+    const payload = {
+      create: vi.fn(async () => {
+        throw transientTransactionError();
+      }),
+      find: vi.fn(async (options) => {
+        if (options.collection === "mediaCategory") {
+          return { docs: [{ id: "category-1", name: "Rooms" }] };
+        }
+
+        return { docs: [] };
+      }),
+      update: vi.fn(),
+    } as unknown as Payload;
+
+    await expect(
+      migrateMediaCategoriesToFolders({
+        payload,
+        retry: false,
+      }),
+    ).rejects.toThrow(/catalog changes/);
+    expect(payload.create).toHaveBeenCalledOnce();
+  });
+
+  it("can preserve Payload migration transaction calls", async () => {
+    const payload = {
+      create: vi.fn(async () => ({ id: "folder-1" })),
+      find: vi.fn(async (options) => {
+        if (options.collection === "mediaCategory") {
+          return { docs: [{ id: "category-1", name: "Rooms" }] };
+        }
+
+        if (options.collection === "payload-folders") {
+          return { docs: [] };
+        }
+
+        return { docs: [{ id: "media-1" }] };
+      }),
+      update: vi.fn(async () => ({})),
+    } as unknown as Payload;
+
+    await migrateMediaCategoriesToFolders({
+      disableTransaction: false,
+      payload,
+    });
+
+    expect(payload.create).toHaveBeenCalledWith({
+      collection: "payload-folders",
+      data: {
+        folderType: ["media"],
+        name: "Rooms",
+      },
+      disableTransaction: false,
+    });
+    expect(payload.update).toHaveBeenCalledWith({
+      collection: "media",
+      data: { folder: "folder-1" },
+      disableTransaction: false,
       id: "media-1",
     });
   });


### PR DESCRIPTION
## Problem

`migrateMediaCategoriesToFolders` can run during the first deploy that introduces Payload folders. MongoDB may throw transient catalog-change / transaction errors, such as `TransientTransactionError` or `WriteConflict`, when the helper writes to the newly created `payload-folders` collection during `payload migrate`.

## What Changed

- Added configurable retry/backoff support to `migrateMediaCategoriesToFolders`.
- Defaulted helper Local API calls to `disableTransaction: true` so retries can rely on the helper's idempotent folder reuse and already-foldered media skip behavior.
- Added opt-outs for callers that need migration transaction behavior (`disableTransaction: false`) or no helper retries (`retry: false`).
- Documented the retry/transaction tradeoff in the cms-plugin README.
- Added Vitest coverage for transient folder creation failures, partial media update retries, non-retryable errors, disabled retries, transaction preservation, and non-finite retry option values.

## Verification

- `pnpm check`
- `pnpm --filter cms-plugin test:int`
- `pnpm --filter cms-plugin build`
- `pnpm exec prettier --check libs/cms-plugin/src/collections/media/migrate-categories-to-folders.ts libs/cms-plugin/tests/media-organization.test.ts libs/cms-plugin/README.md`
- GitHub Actions checks are green for the PR head commit.

## Risks and Mitigations

- Risk: defaulting to `disableTransaction: true` changes the helper from all-or-nothing migration writes to idempotent writes outside Payload's migration transaction.
- Mitigation: this behavior is documented, covered by tests, and can be opted out with `disableTransaction: false`.
- Risk: retrying after partial progress can inflate result counters.
- Mitigation: per-category retry attempts only merge counters after a successful attempt, and partial retry behavior is covered by Vitest.

## Follow-ups

- None required for this PR.