### PR TITLE
fix(cms-plugin): populate media folder thumbnails

### DIFF
--- a/libs/cms-plugin/src/collections/media/config.ts
+++ b/libs/cms-plugin/src/collections/media/config.ts
@@ -96,6 +96,16 @@ export function Media({
       filename: true,
       height: true,
       mimeType: true,
+      sizes: {
+        thumbnail: {
+          filename: true,
+          height: true,
+          url: true,
+          width: true,
+        },
+      },
+      thumbnailURL: true,
+      url: true,
       width: true,
     },
     defaultSort: "filename",
@@ -109,6 +119,7 @@ export function Media({
       singular: translated("cmsPlugin:media:labels:singular"),
     },
     upload: {
+      adminThumbnail: "thumbnail",
       crop: false,
       disableLocalStorage: true,
       displayPreview: true,

--- a/libs/cms-plugin/tests/media-organization.test.ts
+++ b/libs/cms-plugin/tests/media-organization.test.ts
@@ -41,6 +41,26 @@ describe("media organization config", () => {
     expect(media.folders).toBe(true);
   });
 
+  it("populates upload thumbnail fields for folder media cards", () => {
+    const media = Media();
+
+    expect(media.defaultPopulate).toMatchObject({
+      sizes: {
+        thumbnail: {
+          filename: true,
+          height: true,
+          url: true,
+          width: true,
+        },
+      },
+      thumbnailURL: true,
+      url: true,
+    });
+    expect(media.upload).toMatchObject({
+      adminThumbnail: "thumbnail",
+    });
+  });
+
   it("can retain a hidden category field during folder migration", () => {
     const media = Media({
       organization: "folders",

--- a/libs/cms-plugin/tests/media-organization.test.ts
+++ b/libs/cms-plugin/tests/media-organization.test.ts
@@ -42,7 +42,7 @@ describe("media organization config", () => {
   });
 
   it("populates upload thumbnail fields for folder media cards", () => {
-    const media = Media();
+    const media = Media({ organization: "folders" });
 
     expect(media.defaultPopulate).toMatchObject({
       sizes: {


### PR DESCRIPTION
## What changed

- Added media URL fields to the media collection `defaultPopulate` so Payload folder joins receive usable thumbnail data.
- Explicitly set `upload.adminThumbnail` to the generated `thumbnail` image size.
- Added a focused regression assertion for thumbnail population and admin thumbnail config in folder mode.

## Why

When media folders are enabled, Payload's folder grid uses the related media collection's `defaultPopulate`. The previous media populate config omitted `url`, `thumbnailURL`, and image size URL fields, so folder cards could not render thumbnails and fell back to the generic document icon.

## Risk and mitigation

- Risk is low: the change only adds fields to media's default populated shape and points admin thumbnails at an existing generated image size.
- The regression test now instantiates `Media({ organization: "folders" })` so it covers the folder-specific path called out by the issue.
- No custom CDN/ImageKit URL rewriting is introduced; Payload's existing upload URL handling remains the source of truth.

## Validation

- `pnpm --filter cms-plugin test:int -- tests/media-organization.test.ts`
- `pnpm --filter cms-plugin build`
- `pnpm check`

## Follow-ups

- If a deployment needs ImageKit-specific thumbnail transforms instead of Payload/S3 URLs, add that as a separate configurable URL strategy.
